### PR TITLE
feat: implement federation and retrieval (#7 FEAT-005)

### DIFF
--- a/core/schemas/federation/mount-resolution.schema.json
+++ b/core/schemas/federation/mount-resolution.schema.json
@@ -4,7 +4,7 @@
   "title": "K-DLC verified mount resolution",
   "type": "object",
   "additionalProperties": false,
-  "required": ["alias", "id", "uri", "resolved_ref", "manifest_hash", "tree_hash", "mode", "access", "root"],
+  "required": ["alias", "id", "uri", "resolved_ref", "manifest_hash", "tree_hash", "catalog_hash", "retrieval_catalog", "mode", "access", "root"],
   "properties": {
     "alias": {"$ref": "../common.schema.json#/$defs/dnsName"},
     "id": {"$ref": "../common.schema.json#/$defs/knowledgeBaseId"},
@@ -14,6 +14,19 @@
     "resolved_ref": {"$ref": "../common.schema.json#/$defs/nonEmptyString"},
     "manifest_hash": {"$ref": "../common.schema.json#/$defs/digest"},
     "tree_hash": {"$ref": "../common.schema.json#/$defs/digest"},
+    "catalog_hash": {"$ref": "../common.schema.json#/$defs/digest"},
+    "retrieval_catalog": {
+      "type": "array",
+      "items": {
+        "type": "object", "additionalProperties": false, "required": ["id", "path", "byte_hash", "access"],
+        "properties": {
+          "id": {"$ref": "../common.schema.json#/$defs/nonEmptyString"},
+          "path": {"type": "string", "pattern": "^[^/\\\\](?:.*[^/])?\\.md$"},
+          "byte_hash": {"$ref": "../common.schema.json#/$defs/digest"},
+          "access": {"$ref": "../common.schema.json#/$defs/access"}
+        }
+      }
+    },
     "mode": {"enum": ["read-only", "propose", "draft", "maintain", "publish"]},
     "access": {"$ref": "../common.schema.json#/$defs/access"},
     "role": {"enum": ["primary", "dependency"]},

--- a/core/schemas/federation/mount-resolution.schema.json
+++ b/core/schemas/federation/mount-resolution.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kdlc.dev/schemas/v1alpha1/federation/mount-resolution.schema.json",
+  "title": "K-DLC verified mount resolution",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["alias", "id", "uri", "resolved_ref", "manifest_hash", "tree_hash", "mode", "access", "root"],
+  "properties": {
+    "alias": {"$ref": "../common.schema.json#/$defs/dnsName"},
+    "id": {"$ref": "../common.schema.json#/$defs/knowledgeBaseId"},
+    "version": {"$ref": "../common.schema.json#/$defs/nonEmptyString"},
+    "uri": {"$ref": "../common.schema.json#/$defs/resource"},
+    "requested_ref": {"$ref": "../common.schema.json#/$defs/nonEmptyString"},
+    "resolved_ref": {"$ref": "../common.schema.json#/$defs/nonEmptyString"},
+    "manifest_hash": {"$ref": "../common.schema.json#/$defs/digest"},
+    "tree_hash": {"$ref": "../common.schema.json#/$defs/digest"},
+    "mode": {"enum": ["read-only", "propose", "draft", "maintain", "publish"]},
+    "access": {"$ref": "../common.schema.json#/$defs/access"},
+    "role": {"enum": ["primary", "dependency"]},
+    "priority": {"type": "integer"},
+    "root": {"$ref": "../common.schema.json#/$defs/nonEmptyString"}
+  }
+}

--- a/core/schemas/retrieval/response.schema.json
+++ b/core/schemas/retrieval/response.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kdlc.dev/schemas/v1alpha1/retrieval/response.schema.json",
+  "title": "K-DLC federated retrieval response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["status", "results", "citations", "conflicts", "warnings", "timing_class"],
+  "properties": {
+    "status": {"enum": ["ok", "not_found"]},
+    "timing_class": {"const": "bounded-floor"},
+    "results": {"type": "array", "items": {"$ref": "#/$defs/result"}},
+    "citations": {"type": "array", "items": {"$ref": "#/$defs/citation"}},
+    "conflicts": {"type": "array", "items": {"$ref": "#/$defs/conflict"}},
+    "warnings": {"type": "array", "items": {"$ref": "#/$defs/warning"}},
+    "retrieved_at": {"$ref": "../common.schema.json#/$defs/dateTime"},
+    "resolved_bases": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object", "additionalProperties": false, "required": ["revision", "tree_hash"],
+        "properties": {"revision": {"$ref": "../common.schema.json#/$defs/nonEmptyString"}, "tree_hash": {"$ref": "../common.schema.json#/$defs/digest"}}
+      }
+    }
+  },
+  "allOf": [
+    {"if": {"properties": {"status": {"const": "not_found"}}}, "then": {"properties": {"results": {"type": "array", "maxItems": 0}, "citations": {"type": "array", "maxItems": 0}, "conflicts": {"type": "array", "maxItems": 0}, "warnings": {"type": "array", "maxItems": 0}}}},
+    {"if": {"properties": {"status": {"const": "ok"}}}, "then": {"properties": {"results": {"type": "array", "minItems": 1}}}}
+  ],
+  "$defs": {
+    "result": {
+      "type": "object", "additionalProperties": false,
+      "required": ["id", "title", "description", "score", "trust", "freshness", "citation", "source_citations", "applicability"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^kb://"},
+        "title": {"$ref": "../common.schema.json#/$defs/nonEmptyString"},
+        "description": {"type": ["string", "null"]},
+        "score": {"type": "number", "minimum": 0},
+        "trust": {"enum": ["unverified", "machine-confirmed", "human-reviewed"]},
+        "freshness": {"enum": ["current", "stale"]},
+        "citation": {"$ref": "#/$defs/citation"},
+        "source_citations": {"type": "array", "items": {"$ref": "#/$defs/sourceCitation"}},
+        "applicability": true
+      }
+    },
+    "sourceCitation": {
+      "type": "object", "additionalProperties": false, "required": ["id", "resource"],
+      "properties": {"id": {"$ref": "../common.schema.json#/$defs/nonEmptyString"}, "resource": {"$ref": "../common.schema.json#/$defs/resource"}, "source_hash": {"$ref": "../common.schema.json#/$defs/digest"}}
+    },
+    "conflict": {
+      "type": "object", "additionalProperties": false, "required": ["subject", "target", "relationship", "applicability"],
+      "properties": {"subject": {"type": "string", "pattern": "^kb://"}, "target": {"type": "string", "pattern": "^kb://"}, "relationship": {"$ref": "../common.schema.json#/$defs/nonEmptyString"}, "applicability": true}
+    },
+    "warning": {
+      "type": "object", "additionalProperties": false, "required": ["code", "subject"],
+      "properties": {"code": {"const": "KDLC_STALE"}, "subject": {"type": "string", "pattern": "^kb://"}}
+    },
+    "citation": {
+      "type": "object", "additionalProperties": false,
+      "required": ["concept", "knowledge_base_id", "revision", "tree_hash"],
+      "properties": {
+        "concept": {"type": "string", "pattern": "^kb://"},
+        "knowledge_base_id": {"$ref": "../common.schema.json#/$defs/knowledgeBaseId"},
+        "revision": {"$ref": "../common.schema.json#/$defs/nonEmptyString"},
+        "tree_hash": {"$ref": "../common.schema.json#/$defs/digest"}
+      }
+    }
+  }
+}

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -99,9 +99,12 @@
       "id": "FEAT-005",
       "title": "Federation and lexical retrieval",
       "issue": 7,
-      "specification_sections": ["18", "19", "20", "21", "27.3", "34", "35"],
-      "status": "planned",
-      "evidence": {"implementation": [], "tests": []}
+      "specification_sections": ["18", "19", "20", "21", "27.3", "34", "35.8", "35.9"],
+      "status": "implemented",
+      "evidence": {
+        "implementation": ["core/schemas/federation/mount-resolution.schema.json", "core/schemas/retrieval/response.schema.json", "packages/federation/index.mjs", "packages/retrieval/index.mjs"],
+        "tests": ["tests/governance/federation-retrieval.test.mjs"]
+      }
     },
     {
       "id": "FEAT-006",

--- a/packages/contracts/index.mjs
+++ b/packages/contracts/index.mjs
@@ -26,7 +26,9 @@ export const CONTRACT_SCHEMA_PATHS = Object.freeze({
   lifecycleTransaction: "core/schemas/lifecycle/transaction.schema.json",
   lifecycleAuditEvent: "core/schemas/lifecycle/audit-event.schema.json",
   lifecycleLeaseLock: "core/schemas/lifecycle/lease-lock.schema.json",
-  lifecycleSensorResult: "core/schemas/lifecycle/sensor-result.schema.json"
+  lifecycleSensorResult: "core/schemas/lifecycle/sensor-result.schema.json",
+  federationMountResolution: "core/schemas/federation/mount-resolution.schema.json",
+  retrievalResponse: "core/schemas/retrieval/response.schema.json"
 });
 
 export async function loadContractSchemas(root = moduleRoot, additionalPaths = {}) {

--- a/packages/federation/index.mjs
+++ b/packages/federation/index.mjs
@@ -1,0 +1,4 @@
+export * from "./src/errors.mjs";
+export * from "./src/resolver.mjs";
+export * from "./src/routing.mjs";
+export * from "./src/tree.mjs";

--- a/packages/federation/src/errors.mjs
+++ b/packages/federation/src/errors.mjs
@@ -1,0 +1,12 @@
+export class FederationError extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = "FederationError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export function federationFail(code, message, details) {
+  throw new FederationError(code, message, details);
+}

--- a/packages/federation/src/resolver.mjs
+++ b/packages/federation/src/resolver.mjs
@@ -49,13 +49,15 @@ async function readRetrievalCatalog(root) {
     const expectedId = safePath ? entry.path.slice(0, -3) : null;
     const access = entry?.access;
     const validAccess = access && typeof access === "object" && !Array.isArray(access) && typeof access.classification === "string"
-      && (access.compartments === undefined || (Array.isArray(access.compartments) && access.compartments.every((item) => typeof item === "string")));
+      && (access.compartments === undefined || (Array.isArray(access.compartments) && access.compartments.every((item) => typeof item === "string")))
+      && (access.policy_ref === undefined || (typeof access.policy_ref === "string" && access.policy_ref.length > 0));
     if (!safePath || entry?.id !== expectedId || !/^sha256:[0-9a-f]{64}$/.test(entry?.byte_hash ?? "") || !validAccess || ids.has(entry.id) || paths.has(entry.path)) {
       federationFail("KDLC_RETRIEVAL_CATALOG", "Mounted retrieval catalog contains an invalid or duplicate concept entry");
     }
     ids.add(entry.id); paths.add(entry.path);
     return Object.freeze({ id: entry.id, path: entry.path, byte_hash: entry.byte_hash,
-      access: Object.freeze({ classification: access.classification, ...(access.compartments ? { compartments: Object.freeze([...access.compartments]) } : {}) }) });
+      access: Object.freeze({ classification: access.classification, ...(access.compartments ? { compartments: Object.freeze([...access.compartments]) } : {}),
+        ...(access.policy_ref ? { policy_ref: access.policy_ref } : {}) }) });
   });
   for (const concept of concepts) {
     let conceptBytes; let parsed;

--- a/packages/federation/src/resolver.mjs
+++ b/packages/federation/src/resolver.mjs
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, readFile, realpath, rename, rm, writeFile } from "node:
 import { promisify } from "node:util";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
-import { artifactHash, byteHash } from "../../core/index.mjs";
+import { artifactHash, byteHash, canonicalJson, parseMarkdownConcept } from "../../core/index.mjs";
 import { createContractValidator, parseAndValidateContract, validateProjectSemantics } from "../../contracts/index.mjs";
 import { NodeFileStore } from "../../lifecycle/src/index.mjs";
 import { federationFail } from "./errors.mjs";
@@ -35,6 +35,37 @@ async function readManifest(root) {
     federationFail("KDLC_FEDERATION_MANIFEST", "Mounted knowledge-base manifest has no valid stable ID");
   }
   return { manifest, manifest_hash: byteHash(bytes) };
+}
+
+async function readRetrievalCatalog(root) {
+  let bytes; let value;
+  try { bytes = await readFile(join(root, "retrieval-catalog.json")); value = JSON.parse(bytes.toString("utf8")); }
+  catch (error) { federationFail("KDLC_RETRIEVAL_CATALOG", "Mounted base lacks a valid retrieval catalog", { cause: error?.code }); }
+  if (value?.version !== "kdlc-retrieval-catalog-1" || !Array.isArray(value.concepts)) federationFail("KDLC_RETRIEVAL_CATALOG", "Mounted retrieval catalog has an invalid shape");
+  const ids = new Set(); const paths = new Set();
+  const concepts = value.concepts.map((entry) => {
+    const safePath = typeof entry?.path === "string" && entry.path.endsWith(".md") && !entry.path.startsWith("/") && !entry.path.includes("\\")
+      && entry.path.split("/").every((part) => part && part !== "." && part !== "..");
+    const expectedId = safePath ? entry.path.slice(0, -3) : null;
+    const access = entry?.access;
+    const validAccess = access && typeof access === "object" && !Array.isArray(access) && typeof access.classification === "string"
+      && (access.compartments === undefined || (Array.isArray(access.compartments) && access.compartments.every((item) => typeof item === "string")));
+    if (!safePath || entry?.id !== expectedId || !/^sha256:[0-9a-f]{64}$/.test(entry?.byte_hash ?? "") || !validAccess || ids.has(entry.id) || paths.has(entry.path)) {
+      federationFail("KDLC_RETRIEVAL_CATALOG", "Mounted retrieval catalog contains an invalid or duplicate concept entry");
+    }
+    ids.add(entry.id); paths.add(entry.path);
+    return Object.freeze({ id: entry.id, path: entry.path, byte_hash: entry.byte_hash,
+      access: Object.freeze({ classification: access.classification, ...(access.compartments ? { compartments: Object.freeze([...access.compartments]) } : {}) }) });
+  });
+  for (const concept of concepts) {
+    let conceptBytes; let parsed;
+    try { conceptBytes = await readFile(join(root, concept.path)); parsed = parseMarkdownConcept(conceptBytes); }
+    catch { federationFail("KDLC_RETRIEVAL_CATALOG", "Mounted retrieval catalog references invalid concept content"); }
+    if (byteHash(conceptBytes) !== concept.byte_hash || canonicalJson(parsed.frontmatter.access ?? null) !== canonicalJson(concept.access)) {
+      federationFail("KDLC_RETRIEVAL_CATALOG", "Mounted retrieval catalog does not bind concept bytes and access metadata");
+    }
+  }
+  return { catalog_hash: byteHash(bytes), retrieval_catalog: Object.freeze(concepts) };
 }
 
 async function runGit(args, cwd) {
@@ -130,6 +161,7 @@ export class FederationResolver {
       const sourceTree = await describeTree(sourceRoot);
       if (resolvedRef === "pending-tree-hash") resolvedRef = sourceTree.tree_hash;
       const { manifest, manifest_hash } = await readManifest(sourceRoot);
+      const { catalog_hash, retrieval_catalog } = await readRetrievalCatalog(sourceRoot);
       const cacheKey = artifactHash({ id: manifest.metadata.id, resolved_ref: resolvedRef, tree_hash: sourceTree.tree_hash }).slice(7);
       const root = join(this.cacheRoot, cacheKey);
       return await this.cacheStore.withMutex(`.coordination/federation-${cacheKey}`, {
@@ -156,9 +188,11 @@ export class FederationResolver {
         }
         const verified = await describeTree(root);
         if (verified.tree_hash !== sourceTree.tree_hash) { await quarantine(root); federationFail("KDLC_CACHE_DRIFT", "Cached mount failed final tree verification"); }
+        const cachedCatalog = await readRetrievalCatalog(root);
+        if (cachedCatalog.catalog_hash !== catalog_hash) { await quarantine(root); federationFail("KDLC_CACHE_DRIFT", "Cached retrieval catalog drifted"); }
         return Object.freeze({ alias: mount.name, id: manifest.metadata.id, version: manifest.metadata.version, uri: mount.uri,
           ...(mount.ref ? { requested_ref: mount.ref } : {}), resolved_ref: resolvedRef, manifest_hash, tree_hash: verified.tree_hash,
-          mode: mount.mode, role: mount.role ?? "dependency", priority: mount.priority ?? 0, access: manifest.access, root });
+          catalog_hash, retrieval_catalog, mode: mount.mode, role: mount.role ?? "dependency", priority: mount.priority ?? 0, access: manifest.access, root });
       });
     } finally { await rm(temporary, { recursive: true, force: true }); }
   }
@@ -186,10 +220,11 @@ export class FederationResolver {
   }
 
   async verify(mount) {
-    const tree = await describeTree(mount.root); const manifest = await readManifest(mount.root);
-    if (tree.tree_hash !== mount.tree_hash || manifest.manifest_hash !== mount.manifest_hash || manifest.manifest.metadata.id !== mount.id) {
-      federationFail("KDLC_CACHE_DRIFT", "Locked mount no longer matches its verified identity");
-    }
-    return true;
+    try {
+      const tree = await describeTree(mount.root); const manifest = await readManifest(mount.root);
+      const catalog = await readRetrievalCatalog(mount.root);
+      if (tree.tree_hash !== mount.tree_hash || manifest.manifest_hash !== mount.manifest_hash || catalog.catalog_hash !== mount.catalog_hash || manifest.manifest.metadata.id !== mount.id) throw new Error("identity mismatch");
+      return true;
+    } catch { federationFail("KDLC_CACHE_DRIFT", "Locked mount no longer matches its verified identity"); }
   }
 }

--- a/packages/federation/src/resolver.mjs
+++ b/packages/federation/src/resolver.mjs
@@ -1,0 +1,195 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdtemp, mkdir, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+
+import { artifactHash, byteHash } from "../../core/index.mjs";
+import { createContractValidator, parseAndValidateContract, validateProjectSemantics } from "../../contracts/index.mjs";
+import { NodeFileStore } from "../../lifecycle/src/index.mjs";
+import { federationFail } from "./errors.mjs";
+import { copyVerifiedTree, describeTree } from "./tree.mjs";
+
+const execFile = promisify(execFileCallback);
+const clock = { now: () => new Date().toISOString(), millis: () => Date.now() };
+const gitEnvironment = Object.freeze(Object.fromEntries([
+  "PATH", "HOME", "SSH_AUTH_SOCK", "LANG", "LC_ALL", "TMPDIR", "TMP", "TEMP",
+  "HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY", "SSL_CERT_FILE", "SSL_CERT_DIR"
+].filter((name) => process.env[name] !== undefined).map((name) => [name, process.env[name]])));
+
+function inside(root, path) {
+  const rel = relative(root, path);
+  return rel === "" || (rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
+}
+
+async function readManifest(root) {
+  let bytes;
+  try { bytes = await readFile(join(root, "knowledge-base.yaml")); }
+  catch (error) { federationFail("KDLC_FEDERATION_MANIFEST", "Mounted base lacks knowledge-base.yaml", { cause: error.code }); }
+  let checked;
+  try { checked = await parseAndValidateContract("knowledgeBase", bytes.toString("utf8")); }
+  catch { federationFail("KDLC_FEDERATION_MANIFEST", "Mounted knowledge-base manifest is invalid YAML"); }
+  if (!checked.valid) federationFail("KDLC_FEDERATION_MANIFEST", "Mounted knowledge-base manifest violates its contract");
+  const manifest = checked.value;
+  const id = manifest?.metadata?.id;
+  if (manifest?.kind !== "KnowledgeBase" || typeof id !== "string" || !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+$/.test(id)) {
+    federationFail("KDLC_FEDERATION_MANIFEST", "Mounted knowledge-base manifest has no valid stable ID");
+  }
+  return { manifest, manifest_hash: byteHash(bytes) };
+}
+
+async function runGit(args, cwd) {
+  try {
+    return (await execFile("git", args, {
+      cwd, encoding: "utf8", maxBuffer: 16 * 1024 * 1024,
+      env: { ...gitEnvironment, GIT_CONFIG_NOSYSTEM: "1", GIT_CONFIG_GLOBAL: "/dev/null", GIT_TERMINAL_PROMPT: "0" }
+    })).stdout.trim();
+  } catch (error) {
+    federationFail("KDLC_GIT_RESOLUTION", "Git mount resolution failed", { exit_code: error.code });
+  }
+}
+
+async function runGitBytes(args, cwd) {
+  try {
+    return (await execFile("git", args, { cwd, encoding: "buffer", maxBuffer: 64 * 1024 * 1024,
+      env: { ...gitEnvironment, GIT_CONFIG_NOSYSTEM: "1", GIT_CONFIG_GLOBAL: "/dev/null", GIT_TERMINAL_PROMPT: "0" } })).stdout;
+  } catch (error) { federationFail("KDLC_GIT_RESOLUTION", "Git mount resolution failed", { exit_code: error.code }); }
+}
+
+function gitUrl(uri) {
+  if (!uri.startsWith("git+")) federationFail("KDLC_MOUNT_SCHEME", `Unsupported mount URI scheme: ${uri}`);
+  const value = uri.slice(4);
+  if (!/^(?:file|https|ssh):\/\//.test(value)) federationFail("KDLC_MOUNT_SCHEME", "Git mounts require git+file, git+https, or git+ssh");
+  let parsed; try { parsed = new URL(value); } catch { federationFail("KDLC_MOUNT_SCHEME", "Git mount URI is invalid"); }
+  if (parsed.password || parsed.search || parsed.hash || (parsed.protocol === "https:" && parsed.username)) federationFail("KDLC_GIT_CREDENTIAL", "Git mount URIs must not embed credentials, query parameters, or fragments");
+  return value;
+}
+
+async function materializeGit(uri, requestedRef, temporaryRoot) {
+  if (typeof requestedRef !== "string" || !requestedRef || requestedRef.startsWith("-") || requestedRef.length > 1024 || /[\0-\x20\x7f]/.test(requestedRef)) federationFail("KDLC_GIT_REF_REQUIRED", "Git mounts require a safe explicit ref");
+  const repository = join(temporaryRoot, "repository.git");
+  await runGit(["-c", "core.hooksPath=/dev/null", "init", "--bare", repository], temporaryRoot);
+  await runGit(["remote", "add", "origin", gitUrl(uri)], repository);
+  await runGit(["-c", "core.hooksPath=/dev/null", "fetch", "--depth=1", "--filter=blob:none", "--no-tags", "origin", requestedRef], repository);
+  const resolvedRef = await runGit(["rev-parse", "--verify", "--end-of-options", "FETCH_HEAD^{commit}"], repository);
+  if (!/^[0-9a-f]{40,64}$/.test(resolvedRef)) federationFail("KDLC_GIT_REVISION", "Git did not resolve an immutable commit ID");
+  const listing = await runGitBytes(["ls-tree", "-r", "-z", "--full-tree", resolvedRef], repository);
+  const snapshot = join(temporaryRoot, "snapshot"); await mkdir(snapshot);
+  const records = []; let offset = 0; const decoder = new TextDecoder("utf-8", { fatal: true });
+  for (let index = 0; index < listing.length; index += 1) if (listing[index] === 0) {
+    try { records.push(decoder.decode(listing.subarray(offset, index))); }
+    catch { federationFail("KDLC_GIT_ENTRY", "Git mount paths must be valid UTF-8"); }
+    offset = index + 1;
+  }
+  if (offset !== listing.length) federationFail("KDLC_GIT_ENTRY", "Git tree listing was not NUL terminated");
+  const identities = new Set();
+  for (const encoded of records.filter(Boolean)) {
+    const match = /^(\d{6}) (\w+) ([0-9a-f]+)\t([\s\S]+)$/.exec(encoded);
+    if (!match || match[2] !== "blob" || !["100644", "100755"].includes(match[1])) federationFail("KDLC_GIT_ENTRY", "Git mount contains a symlink, submodule, or unsupported entry");
+    const path = match[4];
+    const identity = path.normalize("NFC");
+    if (identities.has(identity)) federationFail("KDLC_GIT_ENTRY", "Git mount paths collide after canonical Unicode normalization");
+    identities.add(identity);
+    const target = resolve(snapshot, path);
+    if (!inside(snapshot, target) || path.includes("\\") || path.includes("\0") || path.split("/").some((part) => !part || part === "." || part === "..")) federationFail("KDLC_GIT_ENTRY", "Git mount contains an unsafe path");
+    await mkdir(dirname(target), { recursive: true });
+    const bytes = await runGitBytes(["cat-file", "blob", match[3]], repository);
+    await writeFile(target, bytes, { flag: "wx", mode: match[1] === "100755" ? 0o700 : 0o600 });
+  }
+  return { sourceRoot: snapshot, resolvedRef };
+}
+
+async function quarantine(path) {
+  const target = `${path}.quarantine-${process.pid}-${Date.now()}`;
+  try { await rename(path, target); return target; }
+  catch (error) { if (error?.code === "ENOENT") return null; federationFail("KDLC_CACHE_QUARANTINE", "Cache drift could not be quarantined"); }
+}
+
+export class FederationResolver {
+  constructor({ projectRoot, cacheRoot = ".kdlc/mounts", now = () => new Date().toISOString(), coordination = {} }) {
+    this.projectRoot = resolve(projectRoot);
+    this.cacheRoot = isAbsolute(cacheRoot) ? resolve(cacheRoot) : resolve(this.projectRoot, cacheRoot);
+    this.now = now;
+    this.coordination = coordination;
+    this.store = new NodeFileStore(this.projectRoot);
+    this.cacheStore = new NodeFileStore(this.cacheRoot);
+  }
+
+  async resolveMount(mount) {
+    if (typeof mount?.name !== "string" || typeof mount?.uri !== "string" || !["read-only", "propose", "draft", "maintain", "publish"].includes(mount?.mode)) federationFail("KDLC_MOUNT_INVALID", "Mount name, URI, and a valid mode are required");
+    if (!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(mount.name) || mount.uri.includes("\0")) federationFail("KDLC_MOUNT_INVALID", "Mount identity or URI is invalid");
+    await mkdir(this.cacheRoot, { recursive: true });
+    const temporary = await mkdtemp(join(this.cacheRoot, ".incoming-"));
+    try {
+      let sourceRoot; let resolvedRef;
+      if (mount.uri.startsWith("git+")) ({ sourceRoot, resolvedRef } = await materializeGit(mount.uri, mount.ref, temporary));
+      else {
+        const candidate = resolve(this.projectRoot, mount.uri);
+        try { sourceRoot = await realpath(candidate); } catch { federationFail("KDLC_LOCAL_MOUNT", "Local mount does not resolve"); }
+        resolvedRef = "pending-tree-hash";
+      }
+      const sourceTree = await describeTree(sourceRoot);
+      if (resolvedRef === "pending-tree-hash") resolvedRef = sourceTree.tree_hash;
+      const { manifest, manifest_hash } = await readManifest(sourceRoot);
+      const cacheKey = artifactHash({ id: manifest.metadata.id, resolved_ref: resolvedRef, tree_hash: sourceTree.tree_hash }).slice(7);
+      const root = join(this.cacheRoot, cacheKey);
+      return await this.cacheStore.withMutex(`.coordination/federation-${cacheKey}`, {
+        owner: `federation:${mount.name}:${process.pid}`, clock, ...this.coordination
+      }, async () => {
+        let cachePresent = true;
+        try {
+          const existing = await describeTree(root);
+          const existingManifest = await readManifest(root);
+          if (existing.tree_hash !== sourceTree.tree_hash || existingManifest.manifest_hash !== manifest_hash || existingManifest.manifest.metadata.id !== manifest.metadata.id) {
+            await quarantine(root);
+            federationFail("KDLC_CACHE_DRIFT", "Cached mount identity or tree hash drifted");
+          }
+        } catch (error) {
+          if (error?.code !== "ENOENT") { await quarantine(root); throw error; }
+          cachePresent = false;
+        }
+        if (!cachePresent) {
+          const staged = join(this.cacheRoot, `.staged-${cacheKey}-${process.pid}-${Date.now()}`);
+          try {
+            await copyVerifiedTree(sourceRoot, staged, sourceTree);
+            await rename(staged, root);
+          } finally { await rm(staged, { recursive: true, force: true }).catch(() => {}); }
+        }
+        const verified = await describeTree(root);
+        if (verified.tree_hash !== sourceTree.tree_hash) { await quarantine(root); federationFail("KDLC_CACHE_DRIFT", "Cached mount failed final tree verification"); }
+        return Object.freeze({ alias: mount.name, id: manifest.metadata.id, version: manifest.metadata.version, uri: mount.uri,
+          ...(mount.ref ? { requested_ref: mount.ref } : {}), resolved_ref: resolvedRef, manifest_hash, tree_hash: verified.tree_hash,
+          mode: mount.mode, role: mount.role ?? "dependency", priority: mount.priority ?? 0, access: manifest.access, root });
+      });
+    } finally { await rm(temporary, { recursive: true, force: true }); }
+  }
+
+  async resolveProject(project) {
+    await mkdir(this.cacheRoot, { recursive: true });
+    const contracts = await createContractValidator(); const contract = contracts.validate("project", project); const semantic = validateProjectSemantics(project);
+    if (!contract.valid || semantic.length) federationFail("KDLC_PROJECT_INVALID", "Project manifest is invalid", { contract: contract.errors, semantic });
+    return this.store.withMutex(".kdlc/coordination/knowledge-lock", { owner: `knowledge-lock:${process.pid}`, clock, ...this.coordination }, async () => {
+      const resolved = [];
+      for (const mount of project.knowledge_bases ?? []) resolved.push(await this.resolveMount(mount));
+      const ids = new Map();
+      for (const mount of resolved) {
+        if (ids.has(mount.id)) federationFail("KDLC_DUPLICATE_KB_ID", `Duplicate stable knowledge-base ID: ${mount.id}`);
+        ids.set(mount.id, mount.alias);
+      }
+      const knowledge_bases = Object.fromEntries([...resolved].sort((a, b) => a.alias < b.alias ? -1 : a.alias > b.alias ? 1 : 0).map((mount) => [mount.alias, {
+        id: mount.id, version: mount.version, uri: mount.uri, ...(mount.requested_ref ? { requested_ref: mount.requested_ref } : {}),
+        resolved_ref: mount.resolved_ref, manifest_hash: mount.manifest_hash, tree_hash: mount.tree_hash
+      }]));
+      const lock = { api_version: "kdlc.dev/v1alpha1", project: project.metadata.name, resolved_at: this.now(), knowledge_bases };
+      await this.store.writeJsonAtomic("knowledge.lock", lock);
+      return Object.freeze({ lock, mounts: Object.freeze(resolved) });
+    });
+  }
+
+  async verify(mount) {
+    const tree = await describeTree(mount.root); const manifest = await readManifest(mount.root);
+    if (tree.tree_hash !== mount.tree_hash || manifest.manifest_hash !== mount.manifest_hash || manifest.manifest.metadata.id !== mount.id) {
+      federationFail("KDLC_CACHE_DRIFT", "Locked mount no longer matches its verified identity");
+    }
+    return true;
+  }
+}

--- a/packages/federation/src/routing.mjs
+++ b/packages/federation/src/routing.mjs
@@ -1,0 +1,15 @@
+import { federationFail } from "./errors.mjs";
+
+const DIRECT_WRITE = new Set(["draft", "maintain", "publish"]);
+
+export function routeWrite({ mounts, explicitTarget, existingOwner, conceptType, routing = {} }) {
+  const byAlias = new Map(mounts.map((mount) => [mount.alias, mount]));
+  const byId = new Map(mounts.map((mount) => [mount.id, mount]));
+  let targetName = explicitTarget ?? existingOwner ?? routing.by_type?.[conceptType] ?? routing.default_write_target;
+  if (!targetName) federationFail("KDLC_ROUTE_AMBIGUOUS", "A write destination must be selected explicitly");
+  const target = byAlias.get(targetName) ?? byId.get(targetName);
+  if (!target) federationFail("KDLC_ROUTE_UNKNOWN", "The selected write destination is not mounted");
+  if (target.mode === "propose" || target.mode === "read-only") return Object.freeze({ action: "proposal", target: target.alias, knowledge_base_id: target.id });
+  if (!DIRECT_WRITE.has(target.mode)) federationFail("KDLC_ROUTE_DENIED", "The selected mount does not permit writes");
+  return Object.freeze({ action: "write", target: target.alias, knowledge_base_id: target.id });
+}

--- a/packages/federation/src/tree.mjs
+++ b/packages/federation/src/tree.mjs
@@ -1,0 +1,68 @@
+import { chmod, copyFile, lstat, mkdir, opendir, readFile } from "node:fs/promises";
+import { dirname, join, relative, resolve, sep } from "node:path";
+
+import { artifactHash, byteHash } from "../../core/index.mjs";
+import { federationFail } from "./errors.mjs";
+
+const IGNORED_ROOTS = new Set([".git", ".kdlc"]);
+
+function portable(root, path) {
+  const value = relative(root, path).split(sep).join("/").normalize("NFC");
+  if (!value || value === ".." || value.startsWith("../") || value.includes("\0")) {
+    federationFail("KDLC_FEDERATION_PATH", "A materialized path escapes its knowledge-base root");
+  }
+  return value;
+}
+
+export async function describeTree(root, { maxFiles = 100_000, maxBytes = 1024 * 1024 * 1024, maxFileBytes = 64 * 1024 * 1024 } = {}) {
+  const canonicalRoot = resolve(root);
+  const entries = []; const identities = new Set(); let totalBytes = 0;
+  async function visit(directory, depth = 0) {
+    if (depth > 128) federationFail("KDLC_FEDERATION_TREE_DEPTH", "Knowledge-base tree exceeds the traversal depth limit");
+    const handle = await opendir(directory);
+    const children = [];
+    for await (const entry of handle) children.push(entry);
+    children.sort((left, right) => left.name.normalize("NFC") < right.name.normalize("NFC") ? -1 : left.name.normalize("NFC") > right.name.normalize("NFC") ? 1 : 0);
+    for (const entry of children) {
+      if (depth === 0 && IGNORED_ROOTS.has(entry.name)) continue;
+      const path = join(directory, entry.name);
+      const metadata = await lstat(path);
+      if (metadata.isSymbolicLink()) federationFail("KDLC_FEDERATION_SYMLINK", `Knowledge-base snapshots reject symlinks: ${portable(canonicalRoot, path)}`);
+      if (metadata.isDirectory()) await visit(path, depth + 1);
+      else if (metadata.isFile()) {
+        const name = portable(canonicalRoot, path);
+        if (identities.has(name)) federationFail("KDLC_FEDERATION_PATH_COLLISION", `Duplicate canonical path: ${name}`);
+        identities.add(name);
+        if (entries.length >= maxFiles || metadata.size > maxFileBytes || totalBytes + metadata.size > maxBytes) {
+          federationFail("KDLC_FEDERATION_TREE_LIMIT", "Knowledge-base snapshot exceeds its file or byte limit");
+        }
+        totalBytes += metadata.size;
+        entries.push(Object.freeze({ path: name, mode: metadata.mode & 0o111 ? "executable" : "regular", hash: byteHash(await readFile(path)) }));
+      } else federationFail("KDLC_FEDERATION_FILE_TYPE", `Unsupported file type in knowledge base: ${portable(canonicalRoot, path)}`);
+    }
+  }
+  await visit(canonicalRoot);
+  entries.sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
+  return Object.freeze({ entries: Object.freeze(entries), tree_hash: artifactHash({ version: 1, entries }) });
+}
+
+export async function copyVerifiedTree(source, destination, expected) {
+  await mkdir(destination, { recursive: false, mode: 0o700 });
+  const directories = new Set([destination]);
+  for (const entry of expected.entries) {
+    const from = resolve(source, entry.path);
+    const to = resolve(destination, entry.path);
+    if (!from.startsWith(`${resolve(source)}${sep}`) || !to.startsWith(`${resolve(destination)}${sep}`)) {
+      federationFail("KDLC_FEDERATION_PATH", "Snapshot copy path escaped its root");
+    }
+    await mkdir(dirname(to), { recursive: true, mode: 0o700 });
+    let parent = dirname(to);
+    while (parent !== destination && parent.startsWith(`${destination}${sep}`)) { directories.add(parent); parent = dirname(parent); }
+    await copyFile(from, to);
+    await chmod(to, entry.mode === "executable" ? 0o555 : 0o444);
+  }
+  const actual = await describeTree(destination);
+  if (actual.tree_hash !== expected.tree_hash) federationFail("KDLC_FEDERATION_TREE_DRIFT", "Materialized tree differs from its verified source");
+  for (const directory of [...directories].sort((left, right) => right.length - left.length)) await chmod(directory, 0o555);
+  return actual;
+}

--- a/packages/retrieval/index.mjs
+++ b/packages/retrieval/index.mjs
@@ -1,0 +1,3 @@
+export * from "./src/errors.mjs";
+export * from "./src/index-traversal.mjs";
+export * from "./src/retriever.mjs";

--- a/packages/retrieval/src/errors.mjs
+++ b/packages/retrieval/src/errors.mjs
@@ -1,0 +1,10 @@
+export class RetrievalError extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = "RetrievalError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export function retrievalFail(code, message, details) { throw new RetrievalError(code, message, details); }

--- a/packages/retrieval/src/index-traversal.mjs
+++ b/packages/retrieval/src/index-traversal.mjs
@@ -1,0 +1,44 @@
+import { lstat, readFile, realpath } from "node:fs/promises";
+import { dirname, relative, resolve, sep } from "node:path";
+
+import { resolveContainedPath } from "../../core/index.mjs";
+import { retrievalFail } from "./errors.mjs";
+
+function links(markdown) {
+  const values = [];
+  for (const match of markdown.matchAll(/\[[^\]]*\]\(([^)]+)\)/g)) {
+    const target = match[1].trim().replace(/[?#].*$/, "");
+    if (target && !/^[a-z][a-z0-9+.-]*:/i.test(target) && !target.startsWith("#")) values.push(target);
+  }
+  return values;
+}
+
+export async function traverseHierarchicalIndex(root, { maxIndexes = 10_000, maxConcepts = 100_000 } = {}) {
+  root = await realpath(root);
+  const pending = ["index.md"]; const indexes = new Set(); const concepts = new Set();
+  while (pending.length) {
+    const index = pending.shift();
+    if (indexes.has(index)) continue;
+    if (indexes.size >= maxIndexes) retrievalFail("KDLC_RETRIEVAL_LIMIT", "Hierarchical index traversal exceeded its index limit");
+    let indexPath;
+    try { indexPath = await resolveContainedPath(root, index); }
+    catch (error) { retrievalFail("KDLC_INDEX_INVALID", `Required hierarchical index cannot be resolved: ${index}`, { cause: error.code }); }
+    indexes.add(index);
+    const markdown = await readFile(indexPath, "utf8");
+    for (const target of links(markdown)) {
+      const from = dirname(index);
+      let path;
+      try { path = await resolveContainedPath(root, target, { from: index, requireFile: false }); }
+      catch (error) { retrievalFail("KDLC_INDEX_INVALID", "Hierarchical index contains an unsafe or broken target", { cause: error.code }); }
+      const metadata = await lstat(path);
+      const portable = relative(root, path).split(sep).join("/");
+      if (portable.includes("\\") || portable.split("/").some((part) => !part || part === "." || part === "..")) retrievalFail("KDLC_INDEX_INVALID", "Hierarchical index resolved an unsafe concept identity");
+      if (metadata.isDirectory()) pending.push(`${portable}/index.md`);
+      else if (metadata.isFile() && portable.endsWith(".md") && !portable.endsWith("/index.md") && portable !== "index.md") {
+        concepts.add(portable);
+        if (concepts.size > maxConcepts) retrievalFail("KDLC_RETRIEVAL_LIMIT", "Hierarchical index traversal exceeded its concept limit");
+      } else retrievalFail("KDLC_INDEX_INVALID", "Hierarchical index target must be a Markdown concept or directory");
+    }
+  }
+  return Object.freeze([...concepts].sort());
+}

--- a/packages/retrieval/src/retriever.mjs
+++ b/packages/retrieval/src/retriever.mjs
@@ -1,0 +1,118 @@
+import { readFile } from "node:fs/promises";
+import { performance } from "node:perf_hooks";
+
+import { byteHash, parseMarkdownConcept } from "../../core/index.mjs";
+import { parseYamlArtifact } from "../../contracts/index.mjs";
+import { describeTree } from "../../federation/index.mjs";
+import { traverseHierarchicalIndex } from "./index-traversal.mjs";
+import { retrievalFail } from "./errors.mjs";
+
+const MODES = new Set(["wiki-only", "sources-only", "trusted-only", "fresh-only", "exploratory", "audit", "refresh"]);
+const TRUST = Object.freeze({ unverified: 0, "machine-confirmed": 1, "human-reviewed": 2 });
+const CONFLICT_TYPES = new Set(["contradicting", "conflict", "unresolved"]);
+
+function terms(value) { return [...new Set(String(value).normalize("NFKC").toLocaleLowerCase("en").match(/[\p{L}\p{N}_-]+/gu) ?? [])]; }
+function trustTier(frontmatter) {
+  const values = frontmatter.verified ? (Array.isArray(frontmatter.verified) ? frontmatter.verified : [frontmatter.verified]) : [];
+  const verified = values.filter((event) => event && typeof event === "object" && typeof event.by === "string" && typeof event.at === "string"
+    && /^(?:human:[A-Za-z0-9._@/-]+|process:[A-Za-z0-9._@/-]+|[a-z][a-z0-9_-]*\/[^/\s]+)$/.test(event.by) && Number.isFinite(Date.parse(event.at)));
+  return verified.some(({ by }) => by.startsWith("human:")) ? "human-reviewed" : verified.length ? "machine-confirmed" : "unverified";
+}
+function stale(frontmatter, today) { return frontmatter.stale_after !== undefined && (typeof frontmatter.stale_after !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(frontmatter.stale_after) || today >= frontmatter.stale_after); }
+function list(value) { return Array.isArray(value) ? value : []; }
+function rawScore(query, concept) {
+  const title = terms(concept.frontmatter.title ?? concept.id); const description = terms(concept.frontmatter.description ?? ""); const body = terms(concept.body);
+  return query.reduce((score, term) => score + (title.includes(term) ? 5 : 0) + (description.includes(term) ? 3 : 0) + (body.includes(term) ? 1 : 0), 0);
+}
+function noDisclosure() {
+  return { status: "not_found", results: [], citations: [], conflicts: [], warnings: [], timing_class: "bounded-floor" };
+}
+function livingReference(value) { return typeof value === "string" ? value.replace(/@[^/]+\//, "/") : null; }
+
+async function verifySnapshot(mount) {
+  try {
+    const tree = await describeTree(mount.root); const manifestBytes = await readFile(`${mount.root}/knowledge-base.yaml`);
+    const manifest = parseYamlArtifact(manifestBytes.toString("utf8"));
+    if (tree.tree_hash !== mount.tree_hash || byteHash(manifestBytes) !== mount.manifest_hash || manifest?.metadata?.id !== mount.id) throw new Error("identity mismatch");
+  } catch { retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification"); }
+}
+
+export class FederatedRetriever {
+  constructor({ mounts, policy, now = () => new Date(), minimumDurationMs = 25, monotonic = () => performance.now(), wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms)), audit }) {
+    if (!policy?.authorizeMount || !policy?.authorizeConcept) retrievalFail("KDLC_POLICY_REQUIRED", "Retrieval requires trusted mount and concept authorization functions");
+    this.mounts = [...mounts]; this.policy = policy; this.now = now; this.minimumDurationMs = minimumDurationMs; this.monotonic = monotonic; this.wait = wait; this.audit = audit;
+  }
+
+  async search({ principal, query, mode = "wiki-only", minimumTrust = "unverified", staleBehavior = "warn", limit = 20, includeSources = false }) {
+    const started = this.monotonic();
+    try {
+      if (!MODES.has(mode)) retrievalFail("KDLC_QUERY_MODE", "Unsupported retrieval query mode");
+      if (!(minimumTrust in TRUST)) retrievalFail("KDLC_TRUST_TIER", "Unsupported minimum trust tier");
+      if (!["warn", "exclude", "fail"].includes(staleBehavior)) retrievalFail("KDLC_FRESHNESS_POLICY", "Unsupported stale behavior");
+      if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) retrievalFail("KDLC_RETRIEVAL_LIMIT", "Retrieval limit must be between 1 and 100");
+      const queryTerms = terms(query); if (!queryTerms.length) return noDisclosure();
+      const today = this.now().toISOString().slice(0, 10); const candidates = []; let internallyDenied = false;
+      for (const mount of [...this.mounts].sort((a, b) => b.priority - a.priority || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))) {
+        const mountAllowed = await this.policy.authorizeMount({ principal, mount, queryMode: mode, capability: "read" }) === true;
+        if (!mountAllowed) { internallyDenied = true; continue; }
+        await verifySnapshot(mount);
+        const paths = await traverseHierarchicalIndex(mount.root);
+        for (const path of paths) {
+          const id = path.slice(0, -3); const parsed = parseMarkdownConcept(await readFile(`${mount.root}/${path}`));
+          const concept = { id, path, frontmatter: parsed.frontmatter, body: parsed.body };
+          const sourceLike = path.startsWith("references/sources/") || /source|evidence/i.test(parsed.frontmatter.type ?? "");
+          const status = parsed.frontmatter.status ?? "stable"; const tier = trustTier(parsed.frontmatter); const isStale = stale(parsed.frontmatter, today);
+          const modeEligible = mode === "exploratory" || mode === "audit" || mode === "refresh"
+            ? true : mode === "sources-only" ? sourceLike : !sourceLike && ["stable", "deprecated"].includes(status);
+          const trustEligible = TRUST[tier] >= TRUST[mode === "trusted-only" && minimumTrust === "unverified" ? "human-reviewed" : minimumTrust];
+          const freshnessEligible = !(mode === "fresh-only" || staleBehavior === "exclude") || !isStale;
+          const allowed = await this.policy.authorizeConcept({ principal, mount, concept: { id, access: parsed.frontmatter.access ?? null }, queryMode: mode, capability: "read" }) === true;
+          if (!allowed) { internallyDenied = true; continue; }
+          if (!modeEligible || !trustEligible || !freshnessEligible) continue;
+          const score = rawScore(queryTerms, concept); if (!score) continue;
+          candidates.push({ mount, concept, score, tier, isStale });
+        }
+      }
+      const maxima = new Map(); for (const item of candidates) maxima.set(item.mount.id, Math.max(maxima.get(item.mount.id) ?? 0, item.score));
+      for (const item of candidates) item.normalized = item.score / maxima.get(item.mount.id) + Math.max(-0.01, Math.min(0.01, item.mount.priority / 10000));
+      candidates.sort((a, b) => b.normalized - a.normalized || (a.mount.id < b.mount.id ? -1 : a.mount.id > b.mount.id ? 1 : a.concept.id < b.concept.id ? -1 : a.concept.id > b.concept.id ? 1 : 0));
+      const byReference = new Map(candidates.map((item) => [`kb://${item.mount.id}/${item.concept.id}`, item]));
+      const selectedByReference = new Map(candidates.slice(0, limit).map((item) => [`kb://${item.mount.id}/${item.concept.id}`, item]));
+      for (const item of [...selectedByReference.values()]) for (const relationship of list(item.concept.frontmatter.relationships)) {
+        if (!CONFLICT_TYPES.has(String(relationship.type).toLocaleLowerCase("en"))) continue;
+        const target = livingReference(relationship.target); const related = byReference.get(target);
+        if (related) selectedByReference.set(target, related);
+      }
+      const selected = [...selectedByReference.values()]; const visible = new Set(selectedByReference.keys());
+      const results = []; const citations = []; const warnings = []; const conflicts = [];
+      for (const item of selected) {
+        if (item.isStale && staleBehavior === "fail") return noDisclosure();
+        const qualified = `kb://${item.mount.id}@${item.mount.resolved_ref}/${item.concept.id}`;
+        const citation = { concept: qualified, knowledge_base_id: item.mount.id, revision: item.mount.resolved_ref, tree_hash: item.mount.tree_hash };
+        citations.push(citation);
+        const sourceCitations = [];
+        if (includeSources || mode === "audit") for (const source of list(item.concept.frontmatter.sources)) {
+          if (typeof source?.id !== "string" || typeof source?.resource !== "string" || (source.source_hash !== undefined && !/^sha256:[0-9a-f]{64}$/.test(source.source_hash))) continue;
+          if (await this.policy.authorizeSource?.({ principal, mount: item.mount, concept: item.concept, source, queryMode: mode, capability: "read" }) === true) sourceCitations.push({ id: source.id, resource: source.resource, ...(source.source_hash ? { source_hash: source.source_hash } : {}) });
+        }
+        results.push({ id: `kb://${item.mount.id}/${item.concept.id}`, title: typeof item.concept.frontmatter.title === "string" && item.concept.frontmatter.title ? item.concept.frontmatter.title : item.concept.id.split("/").at(-1),
+          description: typeof item.concept.frontmatter.description === "string" ? item.concept.frontmatter.description : null, score: Number(item.normalized.toFixed(6)), trust: item.tier,
+          freshness: item.isStale ? "stale" : "current", citation, source_citations: sourceCitations,
+          applicability: item.concept.frontmatter.applicability ?? null });
+        if (item.isStale) warnings.push({ code: "KDLC_STALE", subject: `kb://${item.mount.id}/${item.concept.id}` });
+        for (const relationship of list(item.concept.frontmatter.relationships)) {
+          const target = livingReference(relationship.target);
+          if (CONFLICT_TYPES.has(String(relationship.type).toLocaleLowerCase("en")) && visible.has(target)) conflicts.push({ subject: `kb://${item.mount.id}/${item.concept.id}`, target, relationship: relationship.type, applicability: relationship.applicability ?? null });
+        }
+      }
+      if (!results.length) {
+        await this.audit?.({ action: "retrieval.empty", denied: internallyDenied, principal, minimized: true });
+        return noDisclosure();
+      }
+      return { status: "ok", results, citations, conflicts, warnings, timing_class: "bounded-floor", ...(mode === "audit" ? { retrieved_at: this.now().toISOString(), resolved_bases: Object.fromEntries(selected.map(({ mount }) => [mount.id, { revision: mount.resolved_ref, tree_hash: mount.tree_hash }])) } : {}) };
+    } finally {
+      const remaining = this.minimumDurationMs - (this.monotonic() - started);
+      if (remaining > 0) await this.wait(remaining);
+    }
+  }
+}

--- a/packages/retrieval/src/retriever.mjs
+++ b/packages/retrieval/src/retriever.mjs
@@ -33,6 +33,19 @@ function sourceRecord(source) {
   return { id: source.id, resource: source.resource, ...(source.source_hash ? { source_hash: source.source_hash } : {}) };
 }
 function fileIdentity(metadata) { return { dev: metadata.dev, ino: metadata.ino, size: metadata.size, mtimeMs: metadata.mtimeMs }; }
+function deepFreeze(value, seen = new WeakSet()) {
+  if (!value || typeof value !== "object" || seen.has(value)) return value;
+  seen.add(value); for (const member of Object.values(value)) deepFreeze(member, seen); return Object.freeze(value);
+}
+function immutableJson(value) { return deepFreeze(JSON.parse(canonicalJson(value))); }
+function sourcePolicyRecord(source) {
+  const citation = sourceRecord(source); if (!citation) return null;
+  return { ...citation, ...(source.access !== undefined ? { access: source.access } : {}) };
+}
+function dispatchAudit(audit, event) {
+  if (!audit || !event) return;
+  setTimeout(() => { void Promise.resolve().then(() => audit(event)).catch(() => {}); }, 0);
+}
 
 async function verifySnapshot(mount) {
   try {
@@ -63,7 +76,7 @@ export class FederatedRetriever {
 
   async prepareAuthorization({ principal, queryModes = [...MODES] }) {
     if (!Array.isArray(queryModes) || !queryModes.length || queryModes.some((mode) => !MODES.has(mode))) retrievalFail("KDLC_QUERY_MODE", "Authorization snapshot requires supported query modes");
-    let principalHash; try { principalHash = artifactHash(principal ?? null); }
+    let principalHash, principalSnapshot; try { principalSnapshot = immutableJson(principal ?? null); principalHash = artifactHash(principalSnapshot); }
     catch { retrievalFail("KDLC_PRINCIPAL_INVALID", "Retrieval principal must have a stable serializable identity"); }
     const modes = new Map();
     const orderedMounts = [...this.mounts].sort((a, b) => b.priority - a.priority || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
@@ -87,14 +100,15 @@ export class FederatedRetriever {
             if (byteHash(bytes) !== metadata.byte_hash) throw new Error("concept hash mismatch");
             const parsed = parseMarkdownConcept(bytes);
             if (canonicalJson(parsed.frontmatter.access ?? null) !== canonicalJson(metadata.access)) throw new Error("concept access mismatch");
-            const concept = Object.freeze({ id: metadata.id, path: metadata.path, frontmatter: parsed.frontmatter, body: parsed.body });
-            const sources = list(parsed.frontmatter.sources).map((source) => ({ source, citation: sourceRecord(source) })).filter(({ citation }) => citation);
-            const sourceAllowed = await Promise.all(sources.map(({ source }) => this.policy.authorizeSource?.({
-              principal, mount, concept, source, queryMode, capability: "read"
-            })));
+            const concept = immutableJson({ id: metadata.id, path: metadata.path, frontmatter: parsed.frontmatter, body: parsed.body });
+            const sources = list(parsed.frontmatter.sources).map((source) => ({ policySource: sourcePolicyRecord(source), citation: sourceRecord(source) })).filter(({ citation }) => citation);
+            const sourceAllowed = await Promise.all(sources.map(({ policySource }) => this.policy.authorizeSource?.(immutableJson({
+              principal: principalSnapshot, mount: { id: mount.id, ...(mount.alias !== undefined ? { alias: mount.alias } : {}), access: mount.access ?? null }, concept: { id: concept.id, access: concept.frontmatter.access ?? null },
+              source: policySource, queryMode, capability: "read"
+            }))));
             if (sourceAllowed.some((value) => value !== true)) internallyDenied = true;
-            const sourceCitations = sources.filter((_, sourceIndex) => sourceAllowed[sourceIndex] === true).map(({ citation }) => Object.freeze(citation));
-            return Object.freeze({ metadata, concept, sourceCitations: Object.freeze(sourceCitations), fileIdentity: Object.freeze(fileIdentity(await lstat(conceptPath))) });
+            const sourceCitations = immutableJson(sources.filter((_, sourceIndex) => sourceAllowed[sourceIndex] === true).map(({ citation }) => citation));
+            return deepFreeze({ metadata: immutableJson(metadata), concept, sourceCitations, fileIdentity: fileIdentity(await lstat(conceptPath)) });
           } catch (error) {
             if (error?.code?.startsWith?.("KDLC_")) throw error;
             retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification");
@@ -110,14 +124,14 @@ export class FederatedRetriever {
   }
 
   async search({ authorization, principal, query, mode = "wiki-only", minimumTrust = "unverified", staleBehavior = "warn", limit = 20, includeSources = false }) {
-    const started = this.monotonic();
+    const started = this.monotonic(); let auditEvent = null;
     try {
       if (!MODES.has(mode)) retrievalFail("KDLC_QUERY_MODE", "Unsupported retrieval query mode");
       if (!(minimumTrust in TRUST)) retrievalFail("KDLC_TRUST_TIER", "Unsupported minimum trust tier");
       if (!["warn", "exclude", "fail"].includes(staleBehavior)) retrievalFail("KDLC_FRESHNESS_POLICY", "Unsupported stale behavior");
       if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) retrievalFail("KDLC_RETRIEVAL_LIMIT", "Retrieval limit must be between 1 and 100");
-      const authorizationState = authorizationStates.get(authorization); let principalHash;
-      try { principalHash = artifactHash(principal ?? null); } catch { retrievalFail("KDLC_PRINCIPAL_INVALID", "Retrieval principal must have a stable serializable identity"); }
+      const authorizationState = authorizationStates.get(authorization); let principalHash, principalSnapshot;
+      try { principalSnapshot = immutableJson(principal ?? null); principalHash = artifactHash(principalSnapshot); } catch { retrievalFail("KDLC_PRINCIPAL_INVALID", "Retrieval principal must have a stable serializable identity"); }
       const authorizedMode = authorizationState?.modes.get(mode);
       if (!authorizationState || authorizationState.retriever !== this || authorizationState.expiresAt <= this.authorizationMonotonic()
         || authorizationState.principalHash !== principalHash || !authorizedMode) retrievalFail("KDLC_AUTHORIZATION_SNAPSHOT_REQUIRED", "Retrieval requires a matching current precomputed authorization snapshot");
@@ -174,13 +188,14 @@ export class FederatedRetriever {
         }
       }
       if (!results.length) {
-        await this.audit?.({ action: "retrieval.empty", denied: internallyDenied, principal, minimized: true });
+        auditEvent = immutableJson({ action: "retrieval.empty", denied: internallyDenied, principal: principalSnapshot, minimized: true });
         return noDisclosure();
       }
       return { status: "ok", results, citations, conflicts, warnings, timing_class: "bounded-floor", ...(mode === "audit" ? { retrieved_at: this.now().toISOString(), resolved_bases: Object.fromEntries(selected.map(({ mount }) => [mount.id, { revision: mount.resolved_ref, tree_hash: mount.tree_hash }])) } : {}) };
     } finally {
       const remaining = this.minimumDurationMs - (this.monotonic() - started);
       if (remaining > 0) await this.wait(remaining);
+      dispatchAudit(this.audit, auditEvent);
     }
   }
 }

--- a/packages/retrieval/src/retriever.mjs
+++ b/packages/retrieval/src/retriever.mjs
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { performance } from "node:perf_hooks";
 
-import { byteHash, canonicalJson, parseMarkdownConcept } from "../../core/index.mjs";
+import { artifactHash, byteHash, canonicalJson, parseMarkdownConcept } from "../../core/index.mjs";
 import { parseYamlArtifact } from "../../contracts/index.mjs";
 import { traverseHierarchicalIndex } from "./index-traversal.mjs";
 import { retrievalFail } from "./errors.mjs";
@@ -9,6 +9,7 @@ import { retrievalFail } from "./errors.mjs";
 const MODES = new Set(["wiki-only", "sources-only", "trusted-only", "fresh-only", "exploratory", "audit", "refresh"]);
 const TRUST = Object.freeze({ unverified: 0, "machine-confirmed": 1, "human-reviewed": 2 });
 const CONFLICT_TYPES = new Set(["contradicting", "conflict", "unresolved"]);
+const authorizationStates = new WeakMap();
 
 function terms(value) { return [...new Set(String(value).normalize("NFKC").toLocaleLowerCase("en").match(/[\p{L}\p{N}_-]+/gu) ?? [])]; }
 function trustTier(frontmatter) {
@@ -39,32 +40,67 @@ async function verifySnapshot(mount) {
   } catch { retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification"); }
 }
 
+async function verifyMountIdentity(mount) {
+  try {
+    const manifestBytes = await readFile(`${mount.root}/knowledge-base.yaml`); const manifest = parseYamlArtifact(manifestBytes.toString("utf8"));
+    if (byteHash(manifestBytes) !== mount.manifest_hash || manifest?.metadata?.id !== mount.id) throw new Error("identity mismatch");
+  } catch { retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification"); }
+}
+
 export class FederatedRetriever {
-  constructor({ mounts, policy, now = () => new Date(), minimumDurationMs = 25, monotonic = () => performance.now(), wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms)), readConcept = readFile, audit }) {
+  constructor({ mounts, policy, now = () => new Date(), minimumDurationMs = 25, monotonic = () => performance.now(), wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    authorizationTtlMs = 60_000, authorizationMonotonic = () => performance.now(), readConcept = readFile, audit }) {
     if (!policy?.authorizeMount || !policy?.authorizeConcept) retrievalFail("KDLC_POLICY_REQUIRED", "Retrieval requires trusted mount and concept authorization functions");
-    this.mounts = [...mounts]; this.policy = policy; this.now = now; this.minimumDurationMs = minimumDurationMs; this.monotonic = monotonic; this.wait = wait; this.readConcept = readConcept; this.audit = audit;
+    if (!Number.isSafeInteger(authorizationTtlMs) || authorizationTtlMs < 1 || authorizationTtlMs > 300_000) retrievalFail("KDLC_AUTHORIZATION_TTL", "Authorization snapshot lifetime must be between 1 and 300000 milliseconds");
+    this.mounts = [...mounts]; this.policy = policy; this.now = now; this.minimumDurationMs = minimumDurationMs; this.monotonic = monotonic; this.wait = wait;
+    this.authorizationTtlMs = authorizationTtlMs; this.authorizationMonotonic = authorizationMonotonic; this.readConcept = readConcept; this.audit = audit;
   }
 
-  async search({ principal, query, mode = "wiki-only", minimumTrust = "unverified", staleBehavior = "warn", limit = 20, includeSources = false }) {
+  async prepareAuthorization({ principal, queryModes = [...MODES] }) {
+    if (!Array.isArray(queryModes) || !queryModes.length || queryModes.some((mode) => !MODES.has(mode))) retrievalFail("KDLC_QUERY_MODE", "Authorization snapshot requires supported query modes");
+    let principalHash; try { principalHash = artifactHash(principal ?? null); }
+    catch { retrievalFail("KDLC_PRINCIPAL_INVALID", "Retrieval principal must have a stable serializable identity"); }
+    const modes = new Map();
+    const orderedMounts = [...this.mounts].sort((a, b) => b.priority - a.priority || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+    for (const queryMode of [...new Set(queryModes)]) {
+      let internallyDenied = false;
+      const decisions = await Promise.all(orderedMounts.map(async (mount) => {
+        const mountAllowed = await this.policy.authorizeMount({ principal, mount, queryMode, capability: "read" }) === true;
+        if (!mountAllowed) { internallyDenied = true; return null; }
+        await verifySnapshot(mount);
+        const paths = await traverseHierarchicalIndex(mount.root); const catalogPaths = mount.retrieval_catalog.map(({ path }) => path).sort();
+        if (canonicalJson([...paths].sort()) !== canonicalJson(catalogPaths)) retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification");
+        const allowed = await Promise.all(mount.retrieval_catalog.map((metadata) => this.policy.authorizeConcept({
+          principal, mount, concept: { id: metadata.id, access: metadata.access }, queryMode, capability: "read"
+        })));
+        if (allowed.some((value) => value !== true)) internallyDenied = true;
+        return Object.freeze({ mount, concepts: Object.freeze(mount.retrieval_catalog.filter((_, index) => allowed[index] === true)) });
+      }));
+      modes.set(queryMode, Object.freeze({ internallyDenied, mounts: Object.freeze(decisions.filter(Boolean)) }));
+    }
+    const snapshot = Object.freeze({ kind: "kdlc-retrieval-authorization-1" });
+    authorizationStates.set(snapshot, Object.freeze({ retriever: this, principalHash, modes, expiresAt: this.authorizationMonotonic() + this.authorizationTtlMs }));
+    return snapshot;
+  }
+
+  async search({ authorization, principal, query, mode = "wiki-only", minimumTrust = "unverified", staleBehavior = "warn", limit = 20, includeSources = false }) {
     const started = this.monotonic();
     try {
       if (!MODES.has(mode)) retrievalFail("KDLC_QUERY_MODE", "Unsupported retrieval query mode");
       if (!(minimumTrust in TRUST)) retrievalFail("KDLC_TRUST_TIER", "Unsupported minimum trust tier");
       if (!["warn", "exclude", "fail"].includes(staleBehavior)) retrievalFail("KDLC_FRESHNESS_POLICY", "Unsupported stale behavior");
       if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) retrievalFail("KDLC_RETRIEVAL_LIMIT", "Retrieval limit must be between 1 and 100");
+      const authorizationState = authorizationStates.get(authorization); let principalHash;
+      try { principalHash = artifactHash(principal ?? null); } catch { retrievalFail("KDLC_PRINCIPAL_INVALID", "Retrieval principal must have a stable serializable identity"); }
+      const authorizedMode = authorizationState?.modes.get(mode);
+      if (!authorizationState || authorizationState.retriever !== this || authorizationState.expiresAt < this.authorizationMonotonic()
+        || authorizationState.principalHash !== principalHash || !authorizedMode) retrievalFail("KDLC_AUTHORIZATION_SNAPSHOT_REQUIRED", "Retrieval requires a matching current precomputed authorization snapshot");
       const queryTerms = terms(query); if (!queryTerms.length) return noDisclosure();
-      const today = this.now().toISOString().slice(0, 10); const eligible = []; let internallyDenied = false;
-      for (const mount of [...this.mounts].sort((a, b) => b.priority - a.priority || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))) {
-        const mountAllowed = await this.policy.authorizeMount({ principal, mount, queryMode: mode, capability: "read" }) === true;
-        if (!mountAllowed) { internallyDenied = true; continue; }
-        await verifySnapshot(mount);
-        const paths = await traverseHierarchicalIndex(mount.root);
-        const catalogPaths = mount.retrieval_catalog.map(({ path }) => path).sort();
-        if (canonicalJson([...paths].sort()) !== canonicalJson(catalogPaths)) retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification");
-        for (const metadata of mount.retrieval_catalog) {
+      const today = this.now().toISOString().slice(0, 10); const eligible = []; const { internallyDenied } = authorizedMode;
+      for (const { mount, concepts } of authorizedMode.mounts) {
+        await verifyMountIdentity(mount);
+        for (const metadata of concepts) {
           const { id, path } = metadata;
-          const allowed = await this.policy.authorizeConcept({ principal, mount, concept: { id, access: metadata.access }, queryMode: mode, capability: "read" }) === true;
-          if (!allowed) { internallyDenied = true; continue; }
           let bytes;
           try { bytes = await this.readConcept(`${mount.root}/${path}`); }
           catch { retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification"); }

--- a/packages/retrieval/src/retriever.mjs
+++ b/packages/retrieval/src/retriever.mjs
@@ -10,15 +10,36 @@ const MODES = new Set(["wiki-only", "sources-only", "trusted-only", "fresh-only"
 const TRUST = Object.freeze({ unverified: 0, "machine-confirmed": 1, "human-reviewed": 2 });
 const CONFLICT_TYPES = new Set(["contradicting", "conflict", "unresolved"]);
 const authorizationStates = new WeakMap();
+const ISO_DATE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const RFC3339 = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-](\d{2}):(\d{2}))$/;
+
+function validCalendarDate(year, month, day) {
+  const y = Number(year); const m = Number(month); const d = Number(day);
+  if (m < 1 || m > 12) return false;
+  const leap = y % 4 === 0 && (y % 100 !== 0 || y % 400 === 0);
+  const days = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return d >= 1 && d <= days[m - 1];
+}
+function validIsoDate(value) {
+  const match = typeof value === "string" ? ISO_DATE.exec(value) : null;
+  return Boolean(match && validCalendarDate(match[1], match[2], match[3]));
+}
+function validRfc3339(value) {
+  const match = typeof value === "string" ? RFC3339.exec(value) : null;
+  if (!match || !validCalendarDate(match[1], match[2], match[3])) return false;
+  const [, , , , hour, minute, second, offsetHour = "00", offsetMinute = "00"] = match;
+  return Number(hour) <= 23 && Number(minute) <= 59 && Number(second) <= 59 && Number(offsetHour) <= 23 && Number(offsetMinute) <= 59
+    && Number.isFinite(Date.parse(value));
+}
 
 function terms(value) { return [...new Set(String(value).normalize("NFKC").toLocaleLowerCase("en").match(/[\p{L}\p{N}_-]+/gu) ?? [])]; }
-function trustTier(frontmatter) {
+function trustTier(frontmatter, now) {
   const values = frontmatter.verified ? (Array.isArray(frontmatter.verified) ? frontmatter.verified : [frontmatter.verified]) : [];
   const verified = values.filter((event) => event && typeof event === "object" && typeof event.by === "string" && typeof event.at === "string"
-    && /^(?:human:[A-Za-z0-9._@/-]+|process:[A-Za-z0-9._@/-]+|[a-z][a-z0-9_-]*\/[^/\s]+)$/.test(event.by) && Number.isFinite(Date.parse(event.at)));
+    && /^(?:human:[A-Za-z0-9._@/-]+|process:[A-Za-z0-9._@/-]+|[a-z][a-z0-9_-]*\/[^/\s]+)$/.test(event.by) && validRfc3339(event.at) && Date.parse(event.at) <= now.getTime());
   return verified.some(({ by }) => by.startsWith("human:")) ? "human-reviewed" : verified.length ? "machine-confirmed" : "unverified";
 }
-function stale(frontmatter, today) { return frontmatter.stale_after !== undefined && (typeof frontmatter.stale_after !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(frontmatter.stale_after) || today >= frontmatter.stale_after); }
+function stale(frontmatter, today) { return frontmatter.stale_after !== undefined && (!validIsoDate(frontmatter.stale_after) || today >= frontmatter.stale_after); }
 function list(value) { return Array.isArray(value) ? value : []; }
 function rawScore(query, concept) {
   const title = terms(concept.frontmatter.title ?? concept.id); const description = terms(concept.frontmatter.description ?? ""); const body = terms(concept.body);
@@ -136,7 +157,7 @@ export class FederatedRetriever {
       if (!authorizationState || authorizationState.retriever !== this || authorizationState.expiresAt <= this.authorizationMonotonic()
         || authorizationState.principalHash !== principalHash || !authorizedMode) retrievalFail("KDLC_AUTHORIZATION_SNAPSHOT_REQUIRED", "Retrieval requires a matching current precomputed authorization snapshot");
       const queryTerms = terms(query); if (!queryTerms.length) return noDisclosure();
-      const today = this.now().toISOString().slice(0, 10); const eligible = []; const { internallyDenied } = authorizedMode;
+      const current = this.now(); const today = current.toISOString().slice(0, 10); const eligible = []; const { internallyDenied } = authorizedMode;
       for (const { mount, concepts } of authorizedMode.mounts) {
         await verifyMountIdentity(mount);
         for (const prepared of concepts) {
@@ -145,7 +166,7 @@ export class FederatedRetriever {
             if (canonicalJson(fileIdentity(await lstat(`${mount.root}/${path}`))) !== canonicalJson(prepared.fileIdentity)) throw new Error("concept identity mismatch");
           } catch { retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification"); }
           const sourceLike = path.startsWith("references/sources/") || /source|evidence/i.test(concept.frontmatter.type ?? "");
-          const status = concept.frontmatter.status ?? "stable"; const tier = trustTier(concept.frontmatter); const isStale = stale(concept.frontmatter, today);
+          const status = concept.frontmatter.status ?? "stable"; const tier = trustTier(concept.frontmatter, current); const isStale = stale(concept.frontmatter, today);
           const modeEligible = mode === "exploratory" || mode === "audit" || mode === "refresh"
             ? true : mode === "sources-only" ? sourceLike : !sourceLike && ["stable", "deprecated"].includes(status);
           const trustEligible = TRUST[tier] >= TRUST[mode === "trusted-only" && minimumTrust === "unverified" ? "human-reviewed" : minimumTrust];

--- a/packages/retrieval/src/retriever.mjs
+++ b/packages/retrieval/src/retriever.mjs
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { lstat, readFile } from "node:fs/promises";
 import { performance } from "node:perf_hooks";
 
 import { artifactHash, byteHash, canonicalJson, parseMarkdownConcept } from "../../core/index.mjs";
@@ -28,6 +28,11 @@ function noDisclosure() {
   return { status: "not_found", results: [], citations: [], conflicts: [], warnings: [], timing_class: "bounded-floor" };
 }
 function livingReference(value) { return typeof value === "string" ? value.replace(/@[^/]+\//, "/") : null; }
+function sourceRecord(source) {
+  if (typeof source?.id !== "string" || typeof source?.resource !== "string" || (source.source_hash !== undefined && !/^sha256:[0-9a-f]{64}$/.test(source.source_hash))) return null;
+  return { id: source.id, resource: source.resource, ...(source.source_hash ? { source_hash: source.source_hash } : {}) };
+}
+function fileIdentity(metadata) { return { dev: metadata.dev, ino: metadata.ino, size: metadata.size, mtimeMs: metadata.mtimeMs }; }
 
 async function verifySnapshot(mount) {
   try {
@@ -74,7 +79,28 @@ export class FederatedRetriever {
           principal, mount, concept: { id: metadata.id, access: metadata.access }, queryMode, capability: "read"
         })));
         if (allowed.some((value) => value !== true)) internallyDenied = true;
-        return Object.freeze({ mount, concepts: Object.freeze(mount.retrieval_catalog.filter((_, index) => allowed[index] === true)) });
+        const concepts = await Promise.all(mount.retrieval_catalog.map(async (metadata, index) => {
+          if (allowed[index] !== true) return null;
+          const conceptPath = `${mount.root}/${metadata.path}`;
+          try {
+            const bytes = await this.readConcept(conceptPath);
+            if (byteHash(bytes) !== metadata.byte_hash) throw new Error("concept hash mismatch");
+            const parsed = parseMarkdownConcept(bytes);
+            if (canonicalJson(parsed.frontmatter.access ?? null) !== canonicalJson(metadata.access)) throw new Error("concept access mismatch");
+            const concept = Object.freeze({ id: metadata.id, path: metadata.path, frontmatter: parsed.frontmatter, body: parsed.body });
+            const sources = list(parsed.frontmatter.sources).map((source) => ({ source, citation: sourceRecord(source) })).filter(({ citation }) => citation);
+            const sourceAllowed = await Promise.all(sources.map(({ source }) => this.policy.authorizeSource?.({
+              principal, mount, concept, source, queryMode, capability: "read"
+            })));
+            if (sourceAllowed.some((value) => value !== true)) internallyDenied = true;
+            const sourceCitations = sources.filter((_, sourceIndex) => sourceAllowed[sourceIndex] === true).map(({ citation }) => Object.freeze(citation));
+            return Object.freeze({ metadata, concept, sourceCitations: Object.freeze(sourceCitations), fileIdentity: Object.freeze(fileIdentity(await lstat(conceptPath))) });
+          } catch (error) {
+            if (error?.code?.startsWith?.("KDLC_")) throw error;
+            retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification");
+          }
+        }));
+        return Object.freeze({ mount, concepts: Object.freeze(concepts.filter(Boolean)) });
       }));
       modes.set(queryMode, Object.freeze({ internallyDenied, mounts: Object.freeze(decisions.filter(Boolean)) }));
     }
@@ -93,30 +119,26 @@ export class FederatedRetriever {
       const authorizationState = authorizationStates.get(authorization); let principalHash;
       try { principalHash = artifactHash(principal ?? null); } catch { retrievalFail("KDLC_PRINCIPAL_INVALID", "Retrieval principal must have a stable serializable identity"); }
       const authorizedMode = authorizationState?.modes.get(mode);
-      if (!authorizationState || authorizationState.retriever !== this || authorizationState.expiresAt < this.authorizationMonotonic()
+      if (!authorizationState || authorizationState.retriever !== this || authorizationState.expiresAt <= this.authorizationMonotonic()
         || authorizationState.principalHash !== principalHash || !authorizedMode) retrievalFail("KDLC_AUTHORIZATION_SNAPSHOT_REQUIRED", "Retrieval requires a matching current precomputed authorization snapshot");
       const queryTerms = terms(query); if (!queryTerms.length) return noDisclosure();
       const today = this.now().toISOString().slice(0, 10); const eligible = []; const { internallyDenied } = authorizedMode;
       for (const { mount, concepts } of authorizedMode.mounts) {
         await verifyMountIdentity(mount);
-        for (const metadata of concepts) {
-          const { id, path } = metadata;
-          let bytes;
-          try { bytes = await this.readConcept(`${mount.root}/${path}`); }
-          catch { retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification"); }
-          if (byteHash(bytes) !== metadata.byte_hash) retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification");
-          const parsed = parseMarkdownConcept(bytes);
-          if (canonicalJson(parsed.frontmatter.access ?? null) !== canonicalJson(metadata.access)) retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification");
-          const concept = { id, path, frontmatter: parsed.frontmatter, body: parsed.body };
-          const sourceLike = path.startsWith("references/sources/") || /source|evidence/i.test(parsed.frontmatter.type ?? "");
-          const status = parsed.frontmatter.status ?? "stable"; const tier = trustTier(parsed.frontmatter); const isStale = stale(parsed.frontmatter, today);
+        for (const prepared of concepts) {
+          const { metadata, concept, sourceCitations } = prepared; const { path } = metadata;
+          try {
+            if (canonicalJson(fileIdentity(await lstat(`${mount.root}/${path}`))) !== canonicalJson(prepared.fileIdentity)) throw new Error("concept identity mismatch");
+          } catch { retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification"); }
+          const sourceLike = path.startsWith("references/sources/") || /source|evidence/i.test(concept.frontmatter.type ?? "");
+          const status = concept.frontmatter.status ?? "stable"; const tier = trustTier(concept.frontmatter); const isStale = stale(concept.frontmatter, today);
           const modeEligible = mode === "exploratory" || mode === "audit" || mode === "refresh"
             ? true : mode === "sources-only" ? sourceLike : !sourceLike && ["stable", "deprecated"].includes(status);
           const trustEligible = TRUST[tier] >= TRUST[mode === "trusted-only" && minimumTrust === "unverified" ? "human-reviewed" : minimumTrust];
           const freshnessEligible = !(mode === "fresh-only" || staleBehavior === "exclude") || !isStale;
           if (!modeEligible || !trustEligible || !freshnessEligible) continue;
           const score = rawScore(queryTerms, concept);
-          eligible.push({ mount, concept, score, tier, isStale });
+          eligible.push({ mount, concept, sourceCitations, score, tier, isStale });
         }
       }
       const candidates = eligible.filter(({ score }) => score > 0);
@@ -140,11 +162,7 @@ export class FederatedRetriever {
         const qualified = `kb://${item.mount.id}@${item.mount.resolved_ref}/${item.concept.id}`;
         const citation = { concept: qualified, knowledge_base_id: item.mount.id, revision: item.mount.resolved_ref, tree_hash: item.mount.tree_hash };
         citations.push(citation);
-        const sourceCitations = [];
-        if (includeSources || mode === "audit") for (const source of list(item.concept.frontmatter.sources)) {
-          if (typeof source?.id !== "string" || typeof source?.resource !== "string" || (source.source_hash !== undefined && !/^sha256:[0-9a-f]{64}$/.test(source.source_hash))) continue;
-          if (await this.policy.authorizeSource?.({ principal, mount: item.mount, concept: item.concept, source, queryMode: mode, capability: "read" }) === true) sourceCitations.push({ id: source.id, resource: source.resource, ...(source.source_hash ? { source_hash: source.source_hash } : {}) });
-        }
+        const sourceCitations = includeSources || mode === "audit" ? item.sourceCitations : [];
         results.push({ id: `kb://${item.mount.id}/${item.concept.id}`, title: typeof item.concept.frontmatter.title === "string" && item.concept.frontmatter.title ? item.concept.frontmatter.title : item.concept.id.split("/").at(-1),
           description: typeof item.concept.frontmatter.description === "string" ? item.concept.frontmatter.description : null, score: Number(item.normalized.toFixed(6)), trust: item.tier,
           freshness: item.isStale ? "stale" : "current", citation, source_citations: sourceCitations,

--- a/packages/retrieval/src/retriever.mjs
+++ b/packages/retrieval/src/retriever.mjs
@@ -1,9 +1,8 @@
 import { readFile } from "node:fs/promises";
 import { performance } from "node:perf_hooks";
 
-import { byteHash, parseMarkdownConcept } from "../../core/index.mjs";
+import { byteHash, canonicalJson, parseMarkdownConcept } from "../../core/index.mjs";
 import { parseYamlArtifact } from "../../contracts/index.mjs";
-import { describeTree } from "../../federation/index.mjs";
 import { traverseHierarchicalIndex } from "./index-traversal.mjs";
 import { retrievalFail } from "./errors.mjs";
 
@@ -31,16 +30,19 @@ function livingReference(value) { return typeof value === "string" ? value.repla
 
 async function verifySnapshot(mount) {
   try {
-    const tree = await describeTree(mount.root); const manifestBytes = await readFile(`${mount.root}/knowledge-base.yaml`);
+    const manifestBytes = await readFile(`${mount.root}/knowledge-base.yaml`);
+    const catalogBytes = await readFile(`${mount.root}/retrieval-catalog.json`);
     const manifest = parseYamlArtifact(manifestBytes.toString("utf8"));
-    if (tree.tree_hash !== mount.tree_hash || byteHash(manifestBytes) !== mount.manifest_hash || manifest?.metadata?.id !== mount.id) throw new Error("identity mismatch");
+    const catalog = JSON.parse(catalogBytes.toString("utf8"));
+    if (byteHash(manifestBytes) !== mount.manifest_hash || byteHash(catalogBytes) !== mount.catalog_hash || manifest?.metadata?.id !== mount.id
+      || canonicalJson(catalog.concepts) !== canonicalJson(mount.retrieval_catalog)) throw new Error("identity mismatch");
   } catch { retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification"); }
 }
 
 export class FederatedRetriever {
-  constructor({ mounts, policy, now = () => new Date(), minimumDurationMs = 25, monotonic = () => performance.now(), wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms)), audit }) {
+  constructor({ mounts, policy, now = () => new Date(), minimumDurationMs = 25, monotonic = () => performance.now(), wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms)), readConcept = readFile, audit }) {
     if (!policy?.authorizeMount || !policy?.authorizeConcept) retrievalFail("KDLC_POLICY_REQUIRED", "Retrieval requires trusted mount and concept authorization functions");
-    this.mounts = [...mounts]; this.policy = policy; this.now = now; this.minimumDurationMs = minimumDurationMs; this.monotonic = monotonic; this.wait = wait; this.audit = audit;
+    this.mounts = [...mounts]; this.policy = policy; this.now = now; this.minimumDurationMs = minimumDurationMs; this.monotonic = monotonic; this.wait = wait; this.readConcept = readConcept; this.audit = audit;
   }
 
   async search({ principal, query, mode = "wiki-only", minimumTrust = "unverified", staleBehavior = "warn", limit = 20, includeSources = false }) {
@@ -51,14 +53,24 @@ export class FederatedRetriever {
       if (!["warn", "exclude", "fail"].includes(staleBehavior)) retrievalFail("KDLC_FRESHNESS_POLICY", "Unsupported stale behavior");
       if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) retrievalFail("KDLC_RETRIEVAL_LIMIT", "Retrieval limit must be between 1 and 100");
       const queryTerms = terms(query); if (!queryTerms.length) return noDisclosure();
-      const today = this.now().toISOString().slice(0, 10); const candidates = []; let internallyDenied = false;
+      const today = this.now().toISOString().slice(0, 10); const eligible = []; let internallyDenied = false;
       for (const mount of [...this.mounts].sort((a, b) => b.priority - a.priority || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))) {
         const mountAllowed = await this.policy.authorizeMount({ principal, mount, queryMode: mode, capability: "read" }) === true;
         if (!mountAllowed) { internallyDenied = true; continue; }
         await verifySnapshot(mount);
         const paths = await traverseHierarchicalIndex(mount.root);
-        for (const path of paths) {
-          const id = path.slice(0, -3); const parsed = parseMarkdownConcept(await readFile(`${mount.root}/${path}`));
+        const catalogPaths = mount.retrieval_catalog.map(({ path }) => path).sort();
+        if (canonicalJson([...paths].sort()) !== canonicalJson(catalogPaths)) retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification");
+        for (const metadata of mount.retrieval_catalog) {
+          const { id, path } = metadata;
+          const allowed = await this.policy.authorizeConcept({ principal, mount, concept: { id, access: metadata.access }, queryMode: mode, capability: "read" }) === true;
+          if (!allowed) { internallyDenied = true; continue; }
+          let bytes;
+          try { bytes = await this.readConcept(`${mount.root}/${path}`); }
+          catch { retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification"); }
+          if (byteHash(bytes) !== metadata.byte_hash) retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification");
+          const parsed = parseMarkdownConcept(bytes);
+          if (canonicalJson(parsed.frontmatter.access ?? null) !== canonicalJson(metadata.access)) retrievalFail("KDLC_MOUNT_INTEGRITY", "An authorized mount failed integrity verification");
           const concept = { id, path, frontmatter: parsed.frontmatter, body: parsed.body };
           const sourceLike = path.startsWith("references/sources/") || /source|evidence/i.test(parsed.frontmatter.type ?? "");
           const status = parsed.frontmatter.status ?? "stable"; const tier = trustTier(parsed.frontmatter); const isStale = stale(parsed.frontmatter, today);
@@ -66,22 +78,24 @@ export class FederatedRetriever {
             ? true : mode === "sources-only" ? sourceLike : !sourceLike && ["stable", "deprecated"].includes(status);
           const trustEligible = TRUST[tier] >= TRUST[mode === "trusted-only" && minimumTrust === "unverified" ? "human-reviewed" : minimumTrust];
           const freshnessEligible = !(mode === "fresh-only" || staleBehavior === "exclude") || !isStale;
-          const allowed = await this.policy.authorizeConcept({ principal, mount, concept: { id, access: parsed.frontmatter.access ?? null }, queryMode: mode, capability: "read" }) === true;
-          if (!allowed) { internallyDenied = true; continue; }
           if (!modeEligible || !trustEligible || !freshnessEligible) continue;
-          const score = rawScore(queryTerms, concept); if (!score) continue;
-          candidates.push({ mount, concept, score, tier, isStale });
+          const score = rawScore(queryTerms, concept);
+          eligible.push({ mount, concept, score, tier, isStale });
         }
       }
+      const candidates = eligible.filter(({ score }) => score > 0);
       const maxima = new Map(); for (const item of candidates) maxima.set(item.mount.id, Math.max(maxima.get(item.mount.id) ?? 0, item.score));
       for (const item of candidates) item.normalized = item.score / maxima.get(item.mount.id) + Math.max(-0.01, Math.min(0.01, item.mount.priority / 10000));
       candidates.sort((a, b) => b.normalized - a.normalized || (a.mount.id < b.mount.id ? -1 : a.mount.id > b.mount.id ? 1 : a.concept.id < b.concept.id ? -1 : a.concept.id > b.concept.id ? 1 : 0));
-      const byReference = new Map(candidates.map((item) => [`kb://${item.mount.id}/${item.concept.id}`, item]));
+      const byReference = new Map(eligible.map((item) => [`kb://${item.mount.id}/${item.concept.id}`, item]));
       const selectedByReference = new Map(candidates.slice(0, limit).map((item) => [`kb://${item.mount.id}/${item.concept.id}`, item]));
       for (const item of [...selectedByReference.values()]) for (const relationship of list(item.concept.frontmatter.relationships)) {
         if (!CONFLICT_TYPES.has(String(relationship.type).toLocaleLowerCase("en"))) continue;
         const target = livingReference(relationship.target); const related = byReference.get(target);
-        if (related) selectedByReference.set(target, related);
+        if (related) {
+          if (related.normalized === undefined) related.normalized = 0;
+          selectedByReference.set(target, related);
+        }
       }
       const selected = [...selectedByReference.values()]; const visible = new Set(selectedByReference.keys());
       const results = []; const citations = []; const warnings = []; const conflicts = [];

--- a/tests/fixtures/federation/base-legacy/index.md
+++ b/tests/fixtures/federation/base-legacy/index.md
@@ -1,0 +1,3 @@
+# Legacy Knowledge
+
+* [Policies](policies/)

--- a/tests/fixtures/federation/base-legacy/knowledge-base.yaml
+++ b/tests/fixtures/federation/base-legacy/knowledge-base.yaml
@@ -1,0 +1,8 @@
+api_version: kdlc.dev/v1alpha1
+kind: KnowledgeBase
+metadata: { id: acme.legacy, name: legacy, title: Legacy Knowledge, version: 2.0.0 }
+format: { type: okf, version: "0.2" }
+profile: base@1
+ownership: { owner: "team:legacy", maintainers: ["team:legacy"] }
+access: { classification: internal }
+publication: { stable_requires: { human_verifiers: 0 }, default_stale_after: 180d }

--- a/tests/fixtures/federation/base-legacy/policies/authentication.md
+++ b/tests/fixtures/federation/base-legacy/policies/authentication.md
@@ -1,0 +1,12 @@
+---
+type: Policy
+title: Legacy Authentication
+description: Legacy clients permit password authentication.
+status: stable
+access: { classification: internal, compartments: [engineering] }
+verified: { by: process:legacy-check, at: 2026-08-01T00:00:00Z }
+stale_after: 2027-01-01
+relationships:
+  - { type: contradicting, target: "kb://acme.primary/policies/authentication", applicability: "legacy clients" }
+---
+Authentication permits passwords for legacy clients.

--- a/tests/fixtures/federation/base-legacy/policies/index.md
+++ b/tests/fixtures/federation/base-legacy/policies/index.md
@@ -1,0 +1,3 @@
+# Policies
+
+* [Authentication](authentication.md)

--- a/tests/fixtures/federation/base-legacy/retrieval-catalog.json
+++ b/tests/fixtures/federation/base-legacy/retrieval-catalog.json
@@ -1,0 +1,6 @@
+{
+  "version": "kdlc-retrieval-catalog-1",
+  "concepts": [
+    {"id":"policies/authentication","path":"policies/authentication.md","byte_hash":"sha256:5d4be3c9440ab5c5252e1b9913635abed81d6c1f818f4595ac9a03b1fca6bc21","access":{"classification":"internal","compartments":["engineering"]}}
+  ]
+}

--- a/tests/fixtures/federation/base-primary/index.md
+++ b/tests/fixtures/federation/base-primary/index.md
@@ -1,0 +1,4 @@
+# Primary Knowledge
+
+* [Policies](policies/)
+* [Sources](references/sources/)

--- a/tests/fixtures/federation/base-primary/knowledge-base.yaml
+++ b/tests/fixtures/federation/base-primary/knowledge-base.yaml
@@ -1,0 +1,8 @@
+api_version: kdlc.dev/v1alpha1
+kind: KnowledgeBase
+metadata: { id: acme.primary, name: primary, title: Primary Knowledge, version: 1.0.0 }
+format: { type: okf, version: "0.2" }
+profile: base@1
+ownership: { owner: "team:primary", maintainers: ["team:primary"] }
+access: { classification: internal }
+publication: { stable_requires: { human_verifiers: 1 }, default_stale_after: 180d }

--- a/tests/fixtures/federation/base-primary/policies/authentication.md
+++ b/tests/fixtures/federation/base-primary/policies/authentication.md
@@ -1,0 +1,14 @@
+---
+type: Policy
+title: Authentication Standard
+description: Authentication requires phishing-resistant credentials.
+status: stable
+access: { classification: internal, compartments: [engineering] }
+verified: { by: human:reviewer, at: 2026-08-01T00:00:00Z }
+stale_after: 2027-01-01
+relationships:
+  - { type: contradicting, target: "kb://acme.legacy/policies/authentication", applicability: "legacy clients" }
+sources:
+  - { id: auth-source, resource: "https://example.invalid/auth", source_hash: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", access: { classification: internal } }
+---
+Authentication must use phishing-resistant credentials.

--- a/tests/fixtures/federation/base-primary/policies/authentication.md
+++ b/tests/fixtures/federation/base-primary/policies/authentication.md
@@ -3,7 +3,7 @@ type: Policy
 title: Authentication Standard
 description: Authentication requires phishing-resistant credentials.
 status: stable
-access: { classification: internal, compartments: [engineering] }
+access: { classification: internal, compartments: [engineering], policy_ref: acme-access@4 }
 verified: { by: human:reviewer, at: 2026-08-01T00:00:00Z }
 stale_after: 2027-01-01
 relationships:

--- a/tests/fixtures/federation/base-primary/policies/index.md
+++ b/tests/fixtures/federation/base-primary/policies/index.md
@@ -1,0 +1,5 @@
+# Policies
+
+* [Authentication](authentication.md)
+* [Nightfall](nightfall.md)
+* [Spoofed Verification](spoof.md)

--- a/tests/fixtures/federation/base-primary/policies/nightfall.md
+++ b/tests/fixtures/federation/base-primary/policies/nightfall.md
@@ -1,0 +1,9 @@
+---
+type: Decision
+title: Project Nightfall
+description: Restricted launch decision.
+status: stable
+access: { classification: restricted, compartments: [nightfall] }
+verified: { by: human:director, at: 2026-08-01T00:00:00Z }
+---
+Nightfall launch authorization is restricted.

--- a/tests/fixtures/federation/base-primary/policies/spoof.md
+++ b/tests/fixtures/federation/base-primary/policies/spoof.md
@@ -1,0 +1,9 @@
+---
+type: Policy
+title: Spoofed Verification
+description: Malformed verification metadata must not elevate trust.
+status: stable
+access: { classification: internal, compartments: [engineering] }
+verified: human:attacker
+---
+Spoofed verification is not trusted.

--- a/tests/fixtures/federation/base-primary/references/sources/authentication.md
+++ b/tests/fixtures/federation/base-primary/references/sources/authentication.md
@@ -1,0 +1,9 @@
+---
+type: Source Evidence
+title: Authentication Evidence
+status: stable
+access: { classification: internal, compartments: [engineering] }
+verified: { by: process:normalizer, at: 2026-08-01T00:00:00Z }
+stale_after: 2026-01-01
+---
+Evidence for phishing-resistant authentication.

--- a/tests/fixtures/federation/base-primary/references/sources/index.md
+++ b/tests/fixtures/federation/base-primary/references/sources/index.md
@@ -1,0 +1,3 @@
+# Sources
+
+* [Authentication Evidence](authentication.md)

--- a/tests/fixtures/federation/base-primary/retrieval-catalog.json
+++ b/tests/fixtures/federation/base-primary/retrieval-catalog.json
@@ -1,0 +1,9 @@
+{
+  "version": "kdlc-retrieval-catalog-1",
+  "concepts": [
+    {"id":"policies/authentication","path":"policies/authentication.md","byte_hash":"sha256:4df849834922dbf2120dbef5ed2d86f27c86bffc820357ba3d2a14f11ef56000","access":{"classification":"internal","compartments":["engineering"]}},
+    {"id":"policies/nightfall","path":"policies/nightfall.md","byte_hash":"sha256:b62e1974df3bb895baef7366665368089f6716c9600f584ed6f1ae4693cc6796","access":{"classification":"restricted","compartments":["nightfall"]}},
+    {"id":"policies/spoof","path":"policies/spoof.md","byte_hash":"sha256:b48df8474df67307fe96aa2d8e225edc25f8b0bbe38d6cf10c1abc6fdcf89fee","access":{"classification":"internal","compartments":["engineering"]}},
+    {"id":"references/sources/authentication","path":"references/sources/authentication.md","byte_hash":"sha256:173ed4cc89b96c4e7c729998301b9ec5e7c6d185719e4e736b988b3d3e28b39b","access":{"classification":"internal","compartments":["engineering"]}}
+  ]
+}

--- a/tests/fixtures/federation/base-primary/retrieval-catalog.json
+++ b/tests/fixtures/federation/base-primary/retrieval-catalog.json
@@ -1,7 +1,7 @@
 {
   "version": "kdlc-retrieval-catalog-1",
   "concepts": [
-    {"id":"policies/authentication","path":"policies/authentication.md","byte_hash":"sha256:4df849834922dbf2120dbef5ed2d86f27c86bffc820357ba3d2a14f11ef56000","access":{"classification":"internal","compartments":["engineering"]}},
+    {"id":"policies/authentication","path":"policies/authentication.md","byte_hash":"sha256:1f130b6ce4e2b2f039cddb49243713a4b286fc18b2fc481869753d0f6c127bbe","access":{"classification":"internal","compartments":["engineering"],"policy_ref":"acme-access@4"}},
     {"id":"policies/nightfall","path":"policies/nightfall.md","byte_hash":"sha256:b62e1974df3bb895baef7366665368089f6716c9600f584ed6f1ae4693cc6796","access":{"classification":"restricted","compartments":["nightfall"]}},
     {"id":"policies/spoof","path":"policies/spoof.md","byte_hash":"sha256:b48df8474df67307fe96aa2d8e225edc25f8b0bbe38d6cf10c1abc6fdcf89fee","access":{"classification":"internal","compartments":["engineering"]}},
     {"id":"references/sources/authentication","path":"references/sources/authentication.md","byte_hash":"sha256:173ed4cc89b96c4e7c729998301b9ec5e7c6d185719e4e736b988b3d3e28b39b","access":{"classification":"internal","compartments":["engineering"]}}

--- a/tests/fixtures/federation/policy-state.json
+++ b/tests/fixtures/federation/policy-state.json
@@ -1,0 +1,6 @@
+{
+  "principal": "human:fixture-reader",
+  "classifications": ["public", "internal"],
+  "compartments": ["engineering"],
+  "query_modes": ["wiki-only", "sources-only", "trusted-only", "fresh-only", "exploratory", "audit", "refresh"]
+}

--- a/tests/governance/core-contracts.test.mjs
+++ b/tests/governance/core-contracts.test.mjs
@@ -106,7 +106,7 @@ test("FEAT-001 vendors the exact pinned OKF 0.2 bytes", async () => {
 
 test("FEAT-001 publishes strict JSON Schema 2020-12 contracts", async () => {
   const schemas = await loadContractSchemas();
-  assert.equal(schemas.length, 18);
+  assert.equal(schemas.length, 20);
   for (const { relativePath, schema } of schemas) {
     assert.equal(schema.$schema, "https://json-schema.org/draft/2020-12/schema", relativePath);
     assert.match(schema.$id, /^https:\/\/kdlc\.dev\/schemas\//, relativePath);

--- a/tests/governance/federation-retrieval.test.mjs
+++ b/tests/governance/federation-retrieval.test.mjs
@@ -124,6 +124,13 @@ function policy(state = policyState) {
   };
 }
 
+async function rewritePrimaryConcept(root, relativePath, transform) {
+  const path = join(root, "primary", relativePath); const body = transform(await readFile(path, "utf8")); await writeFile(path, body);
+  const catalogPath = join(root, "primary", "retrieval-catalog.json"); const catalog = JSON.parse(await readFile(catalogPath, "utf8"));
+  catalog.concepts.find(({ path: candidate }) => candidate === relativePath).byte_hash = byteHash(body);
+  await writeFile(catalogPath, `${JSON.stringify(catalog)}\n`);
+}
+
 test("FEAT-005 traverses hierarchical indexes and retrieves across mounts with qualified conflicts", async (context) => {
   const root = await workspace(context); const { mounts } = await new FederationResolver({ projectRoot: root, now: fixedNow }).resolveProject(project(root));
   assert.deepEqual(await traverseHierarchicalIndex(mounts.find(({ alias }) => alias === "primary").root), [
@@ -181,6 +188,42 @@ test("FEAT-005 applies query-mode, trust, freshness, and access filters before d
   const expiringAuthorization = await expiring.prepareAuthorization({ principal, queryModes: ["wiki-only"] });
   authorizationTime = 110;
   await assert.rejects(expiring.search({ authorization: expiringAuthorization, principal, query: "authentication" }), retrievalCode("KDLC_AUTHORIZATION_SNAPSHOT_REQUIRED"));
+});
+
+test("FEAT-005 trust receipts and freshness dates reject impossible and future calendar values", async (context) => {
+  const invalidRoot = await workspace(context);
+  await rewritePrimaryConcept(invalidRoot, "policies/authentication.md", (body) => body
+    .replace("2026-08-01T00:00:00Z", "2026-02-30T00:00:00Z")
+    .replace("stale_after: 2027-01-01", "stale_after: 2027-02-30"));
+  const invalidMounts = (await new FederationResolver({ projectRoot: invalidRoot, now: fixedNow }).resolveProject(project(invalidRoot))).mounts;
+  const invalidRetriever = new FederatedRetriever({ mounts: invalidMounts, policy: policy(), now: () => new Date("2026-08-14T15:00:00Z") });
+  const invalidPrincipal = {}; const invalidAuthorization = await invalidRetriever.prepareAuthorization({ principal: invalidPrincipal, queryModes: ["trusted-only", "fresh-only"] });
+  assert.equal((await invalidRetriever.search({ authorization: invalidAuthorization, principal: invalidPrincipal, query: "phishing-resistant", mode: "trusted-only" })).status, "not_found");
+  assert.equal((await invalidRetriever.search({ authorization: invalidAuthorization, principal: invalidPrincipal, query: "phishing-resistant", mode: "fresh-only" })).status, "not_found");
+
+  const leapRoot = await workspace(context);
+  await rewritePrimaryConcept(leapRoot, "policies/authentication.md", (body) => body
+    .replace("2026-08-01T00:00:00Z", "2024-02-29T23:59:59Z")
+    .replace("stale_after: 2027-01-01", "stale_after: 2028-02-29"));
+  const leapMounts = (await new FederationResolver({ projectRoot: leapRoot, now: fixedNow }).resolveProject(project(leapRoot))).mounts;
+  const leapPrincipal = {};
+  const beforeBoundary = new FederatedRetriever({ mounts: leapMounts, policy: policy(), now: () => new Date("2028-02-28T23:59:59Z") });
+  const beforeAuthorization = await beforeBoundary.prepareAuthorization({ principal: leapPrincipal, queryModes: ["trusted-only", "fresh-only"] });
+  assert.equal((await beforeBoundary.search({ authorization: beforeAuthorization, principal: leapPrincipal, query: "phishing-resistant", mode: "trusted-only" })).status, "ok");
+  assert.equal((await beforeBoundary.search({ authorization: beforeAuthorization, principal: leapPrincipal, query: "phishing-resistant", mode: "fresh-only" })).status, "ok");
+  const atBoundary = new FederatedRetriever({ mounts: leapMounts, policy: policy(), now: () => new Date("2028-02-29T00:00:00Z") });
+  const boundaryAuthorization = await atBoundary.prepareAuthorization({ principal: leapPrincipal, queryModes: ["fresh-only"] });
+  assert.equal((await atBoundary.search({ authorization: boundaryAuthorization, principal: leapPrincipal, query: "phishing-resistant", mode: "fresh-only" })).status, "not_found");
+
+  const futureRoot = await workspace(context);
+  await rewritePrimaryConcept(futureRoot, "policies/authentication.md", (body) => body.replace("2026-08-01T00:00:00Z", "2026-08-14T15:00:00.000Z"));
+  const futureMounts = (await new FederationResolver({ projectRoot: futureRoot, now: fixedNow }).resolveProject(project(futureRoot))).mounts;
+  const exactRetriever = new FederatedRetriever({ mounts: futureMounts, policy: policy(), now: () => new Date("2026-08-14T15:00:00.000Z") });
+  const exactAuthorization = await exactRetriever.prepareAuthorization({ principal: leapPrincipal, queryModes: ["trusted-only"] });
+  assert.equal((await exactRetriever.search({ authorization: exactAuthorization, principal: leapPrincipal, query: "phishing-resistant", mode: "trusted-only" })).status, "ok");
+  const futureRetriever = new FederatedRetriever({ mounts: futureMounts, policy: policy(), now: () => new Date("2026-08-14T14:59:59.999Z") });
+  const futureAuthorization = await futureRetriever.prepareAuthorization({ principal: leapPrincipal, queryModes: ["trusted-only"] });
+  assert.equal((await futureRetriever.search({ authorization: futureAuthorization, principal: leapPrincipal, query: "phishing-resistant", mode: "trusted-only" })).status, "not_found");
 });
 
 test("FEAT-005 authorizes before concept reads and bounds absent/unauthorized response timing", async (context) => {

--- a/tests/governance/federation-retrieval.test.mjs
+++ b/tests/governance/federation-retrieval.test.mjs
@@ -3,6 +3,7 @@ import { execFile as execFileCallback } from "node:child_process";
 import { chmod, cp, lstat, mkdtemp, opendir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { performance } from "node:perf_hooks";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import test from "node:test";
@@ -91,6 +92,13 @@ test("FEAT-005 rejects duplicate stable IDs, cache drift, unsafe Git entries, an
   await symlink(join(root, "primary", "index.md"), join(root, "unsafe-local", "escape.md"));
   await assert.rejects(resolver.resolveMount({ name: "unsafe", uri: "./unsafe-local", mode: "read-only" }), federationCode("KDLC_FEDERATION_SYMLINK"));
 
+  await cp(join(fixtures, "base-primary"), join(root, "downgraded-access"), { recursive: true });
+  const catalogPath = join(root, "downgraded-access", "retrieval-catalog.json");
+  const downgradedCatalog = JSON.parse(await readFile(catalogPath, "utf8"));
+  downgradedCatalog.concepts.find(({ id }) => id === "policies/nightfall").access = { classification: "internal", compartments: ["engineering"] };
+  await writeFile(catalogPath, `${JSON.stringify(downgradedCatalog)}\n`);
+  await assert.rejects(resolver.resolveMount({ name: "downgrade", uri: "./downgraded-access", mode: "read-only" }), federationCode("KDLC_RETRIEVAL_CATALOG"));
+
   const oldGit = resolved.mounts.find(({ alias }) => alias === "legacy");
   await writeFile(join(root, "legacy-source", "new.md"), "---\ntype: Reference\n---\nnew\n");
   await execFile("git", ["-C", join(root, "legacy-source"), "add", "."]); await execFile("git", ["-C", join(root, "legacy-source"), "commit", "-q", "-m", "next"]);
@@ -125,6 +133,13 @@ test("FEAT-005 traverses hierarchical indexes and retrieves across mounts with q
   assert.equal(response.conflicts.length, 2);
   assert.deepEqual(response.results.find(({ id }) => id.startsWith("kb://acme.primary/")).source_citations.map(({ id }) => id), ["auth-source"]);
   const contracts = await createContractValidator(); assert.equal(contracts.validate("retrievalResponse", response).valid, true);
+
+  const zeroScoreConflict = await retriever.search({ principal: { id: "human:reader" }, query: "phishing-resistant", mode: "wiki-only", limit: 1 });
+  assert.deepEqual(zeroScoreConflict.results.map(({ id }) => id), [
+    "kb://acme.primary/policies/authentication", "kb://acme.legacy/policies/authentication"
+  ]);
+  assert.equal(zeroScoreConflict.results[1].score, 0);
+  assert.equal(zeroScoreConflict.conflicts.length, 2);
 });
 
 test("FEAT-005 applies query-mode, trust, freshness, and access filters before disclosure", async (context) => {
@@ -140,13 +155,22 @@ test("FEAT-005 applies query-mode, trust, freshness, and access filters before d
   await assert.rejects(retriever.search({ principal: {}, query: "authentication", mode: "vector-only" }), retrievalCode("KDLC_QUERY_MODE"));
 });
 
-test("FEAT-005 makes absent and unauthorized results externally indistinguishable with equal timing floor", async (context) => {
+test("FEAT-005 authorizes before concept reads and bounds absent/unauthorized response timing", async (context) => {
   const root = await workspace(context); const { mounts } = await new FederationResolver({ projectRoot: root, now: fixedNow }).resolveProject(project(root));
-  const waits = []; const retriever = new FederatedRetriever({ mounts, policy: policy(), now: () => new Date("2026-08-14T15:00:00Z"),
-    minimumDurationMs: 25, monotonic: () => 0, wait: async (duration) => { waits.push(duration); } });
-  const unauthorized = await retriever.search({ principal: {}, query: "Project Nightfall", mode: "wiki-only" });
-  const absent = await retriever.search({ principal: {}, query: "Project Zephyr", mode: "wiki-only" });
-  assert.deepEqual(unauthorized, absent); assert.deepEqual(waits, [25, 25]);
+  const reads = [];
+  const retriever = new FederatedRetriever({ mounts, policy: policy(), now: () => new Date("2026-08-14T15:00:00Z"), minimumDurationMs: 75,
+    readConcept: async (path) => { reads.push(path); if (path.endsWith("/policies/nightfall.md")) throw new Error("unauthorized body opened"); return readFile(path); } });
+  const durations = []; let unauthorized; let absent;
+  for (let iteration = 0; iteration < 3; iteration += 1) {
+    let started = performance.now(); unauthorized = await retriever.search({ principal: {}, query: "Project Nightfall", mode: "wiki-only" });
+    durations.push(performance.now() - started);
+    started = performance.now(); absent = await retriever.search({ principal: {}, query: "Project Zephyr", mode: "wiki-only" });
+    durations.push(performance.now() - started);
+    assert.deepEqual(unauthorized, absent);
+  }
+  assert.equal(reads.some((path) => path.endsWith("/policies/nightfall.md")), false);
+  assert.equal(durations.every((duration) => duration >= 65), true, `floor was not enforced: ${durations.join(", ")}`);
+  for (let index = 0; index < durations.length; index += 2) assert.equal(Math.abs(durations[index] - durations[index + 1]) < 40, true, `timing classes diverged: ${durations.join(", ")}`);
   assert.deepEqual(Object.keys(absent), ["status", "results", "citations", "conflicts", "warnings", "timing_class"]);
   const contracts = await createContractValidator(); assert.equal(contracts.validate("retrievalResponse", absent).valid, true);
 });

--- a/tests/governance/federation-retrieval.test.mjs
+++ b/tests/governance/federation-retrieval.test.mjs
@@ -8,6 +8,7 @@ import { pathToFileURL, fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import test from "node:test";
 
+import { byteHash } from "../../packages/core/index.mjs";
 import { createContractValidator } from "../../packages/contracts/index.mjs";
 import { FederationError, FederationResolver, routeWrite } from "../../packages/federation/index.mjs";
 import { FederatedRetriever, RetrievalError, traverseHierarchicalIndex } from "../../packages/retrieval/index.mjs";
@@ -60,6 +61,7 @@ test("FEAT-005 resolves local and Git mounts into verified immutable cache and k
     resolver.resolveProject(project(root)), new FederationResolver({ projectRoot: root, now: fixedNow }).resolveProject(project(root))
   ]);
   assert.equal(resolved.mounts.length, 2);
+  assert.equal(resolved.mounts.find(({ alias }) => alias === "primary").retrieval_catalog.find(({ id }) => id === "policies/authentication").access.policy_ref, "acme-access@4");
   assert.match(resolved.mounts[1].resolved_ref, /^[0-9a-f]{40,64}$/);
   assert.equal(await resolver.verify(resolved.mounts[0]), true);
   assert.equal((await stat(resolved.mounts[0].root)).mode & 0o222, 0);
@@ -83,8 +85,9 @@ test("FEAT-005 rejects duplicate stable IDs, cache drift, unsafe Git entries, an
   await chmod(primary.root, 0o755); await chmod(join(primary.root, "policies"), 0o755); await chmod(concept, 0o644);
   await writeFile(concept, `${await readFile(concept, "utf8")}\ndrift\n`);
   await assert.rejects(resolver.verify(primary), federationCode("KDLC_CACHE_DRIFT"));
-  await assert.rejects(new FederatedRetriever({ mounts: resolved.mounts, policy: policy(), now: () => new Date(fixedNow()) })
-    .search({ principal: {}, query: "authentication" }), retrievalCode("KDLC_MOUNT_INTEGRITY"));
+  const driftRetriever = new FederatedRetriever({ mounts: resolved.mounts, policy: policy(), now: () => new Date(fixedNow()) });
+  const driftAuthorization = await driftRetriever.prepareAuthorization({ principal: {}, queryModes: ["wiki-only"] });
+  await assert.rejects(driftRetriever.search({ authorization: driftAuthorization, principal: {}, query: "authentication" }), retrievalCode("KDLC_MOUNT_INTEGRITY"));
   await assert.rejects(resolver.resolveMount(project(root).knowledge_bases[0]), federationCode("KDLC_CACHE_DRIFT"));
   await assert.rejects(stat(primary.root), (error) => error.code === "ENOENT");
 
@@ -127,14 +130,15 @@ test("FEAT-005 traverses hierarchical indexes and retrieves across mounts with q
     "policies/authentication.md", "policies/nightfall.md", "policies/spoof.md", "references/sources/authentication.md"
   ]);
   const retriever = new FederatedRetriever({ mounts, policy: policy(), now: () => new Date("2026-08-14T15:00:00Z") });
-  const response = await retriever.search({ principal: { id: "human:reader" }, query: "authentication", mode: "wiki-only", includeSources: true, limit: 1 });
+  const principal = { id: "human:reader" }; const authorization = await retriever.prepareAuthorization({ principal, queryModes: ["wiki-only"] });
+  const response = await retriever.search({ authorization, principal, query: "authentication", mode: "wiki-only", includeSources: true, limit: 1 });
   assert.equal(response.status, "ok"); assert.equal(response.results.length, 2); assert.equal(response.citations.length, 2);
   assert.match(response.citations[0].concept, /^kb:\/\/acme\.(?:primary|legacy)@[0-9a-z:-]+\/policies\/authentication$/);
   assert.equal(response.conflicts.length, 2);
   assert.deepEqual(response.results.find(({ id }) => id.startsWith("kb://acme.primary/")).source_citations.map(({ id }) => id), ["auth-source"]);
   const contracts = await createContractValidator(); assert.equal(contracts.validate("retrievalResponse", response).valid, true);
 
-  const zeroScoreConflict = await retriever.search({ principal: { id: "human:reader" }, query: "phishing-resistant", mode: "wiki-only", limit: 1 });
+  const zeroScoreConflict = await retriever.search({ authorization, principal, query: "phishing-resistant", mode: "wiki-only", limit: 1 });
   assert.deepEqual(zeroScoreConflict.results.map(({ id }) => id), [
     "kb://acme.primary/policies/authentication", "kb://acme.legacy/policies/authentication"
   ]);
@@ -145,29 +149,43 @@ test("FEAT-005 traverses hierarchical indexes and retrieves across mounts with q
 test("FEAT-005 applies query-mode, trust, freshness, and access filters before disclosure", async (context) => {
   const root = await workspace(context); const { mounts } = await new FederationResolver({ projectRoot: root, now: fixedNow }).resolveProject(project(root));
   const retriever = new FederatedRetriever({ mounts, policy: policy(), now: () => new Date("2026-08-14T15:00:00Z") });
-  const trusted = await retriever.search({ principal: {}, query: "authentication", mode: "trusted-only" });
+  const principal = {}; const authorization = await retriever.prepareAuthorization({ principal, queryModes: ["trusted-only", "sources-only", "fresh-only"] });
+  const trusted = await retriever.search({ authorization, principal, query: "authentication", mode: "trusted-only" });
   assert.deepEqual(trusted.results.map(({ id }) => id), ["kb://acme.primary/policies/authentication"]);
-  assert.equal((await retriever.search({ principal: {}, query: "spoofed verification", mode: "trusted-only" })).status, "not_found");
-  const sources = await retriever.search({ principal: {}, query: "authentication", mode: "sources-only", staleBehavior: "warn" });
+  assert.equal((await retriever.search({ authorization, principal, query: "spoofed verification", mode: "trusted-only" })).status, "not_found");
+  const sources = await retriever.search({ authorization, principal, query: "authentication", mode: "sources-only", staleBehavior: "warn" });
   assert.equal(sources.results.length, 1); assert.equal(sources.results[0].freshness, "stale"); assert.equal(sources.warnings.length, 1);
-  const fresh = await retriever.search({ principal: {}, query: "authentication", mode: "fresh-only" });
+  const fresh = await retriever.search({ authorization, principal, query: "authentication", mode: "fresh-only" });
   assert.equal(fresh.results.some(({ id }) => id.includes("references/sources")), false);
+  await assert.rejects(retriever.search({ principal, query: "authentication", mode: "wiki-only" }), retrievalCode("KDLC_AUTHORIZATION_SNAPSHOT_REQUIRED"));
   await assert.rejects(retriever.search({ principal: {}, query: "authentication", mode: "vector-only" }), retrievalCode("KDLC_QUERY_MODE"));
 });
 
 test("FEAT-005 authorizes before concept reads and bounds absent/unauthorized response timing", async (context) => {
-  const root = await workspace(context); const { mounts } = await new FederationResolver({ projectRoot: root, now: fixedNow }).resolveProject(project(root));
-  const reads = [];
-  const retriever = new FederatedRetriever({ mounts, policy: policy(), now: () => new Date("2026-08-14T15:00:00Z"), minimumDurationMs: 75,
+  const root = await workspace(context); const catalogPath = join(root, "primary", "retrieval-catalog.json");
+  const catalog = JSON.parse(await readFile(catalogPath, "utf8")); const indexPath = join(root, "primary", "policies", "index.md"); let index = await readFile(indexPath, "utf8");
+  for (let number = 0; number < 40; number += 1) {
+    const name = `restricted-${String(number).padStart(2, "0")}`; const body = `---\ntype: Decision\ntitle: Restricted ${number}\nstatus: stable\naccess: { classification: restricted, compartments: [nightfall] }\n---\nRestricted material ${number}.\n`;
+    await writeFile(join(root, "primary", "policies", `${name}.md`), body); index += `* [Restricted ${number}](${name}.md)\n`;
+    catalog.concepts.push({ id: `policies/${name}`, path: `policies/${name}.md`, byte_hash: byteHash(body), access: { classification: "restricted", compartments: ["nightfall"] } });
+  }
+  await writeFile(indexPath, index); await writeFile(catalogPath, `${JSON.stringify(catalog)}\n`);
+  const { mounts } = await new FederationResolver({ projectRoot: root, now: fixedNow }).resolveProject(project(root));
+  const reads = []; let conceptDecisions = 0; const delayedPolicy = policy(); const authorizeConcept = delayedPolicy.authorizeConcept;
+  delayedPolicy.authorizeConcept = async (input) => { conceptDecisions += 1; await new Promise((resolve) => setTimeout(resolve, 12)); return authorizeConcept(input); };
+  const retriever = new FederatedRetriever({ mounts, policy: delayedPolicy, now: () => new Date("2026-08-14T15:00:00Z"), minimumDurationMs: 75,
     readConcept: async (path) => { reads.push(path); if (path.endsWith("/policies/nightfall.md")) throw new Error("unauthorized body opened"); return readFile(path); } });
+  const principal = {}; const authorization = await retriever.prepareAuthorization({ principal, queryModes: ["wiki-only"] }); const preparedDecisions = conceptDecisions;
   const durations = []; let unauthorized; let absent;
   for (let iteration = 0; iteration < 3; iteration += 1) {
-    let started = performance.now(); unauthorized = await retriever.search({ principal: {}, query: "Project Nightfall", mode: "wiki-only" });
+    let started = performance.now(); unauthorized = await retriever.search({ authorization, principal, query: "Project Nightfall", mode: "wiki-only" });
     durations.push(performance.now() - started);
-    started = performance.now(); absent = await retriever.search({ principal: {}, query: "Project Zephyr", mode: "wiki-only" });
+    started = performance.now(); absent = await retriever.search({ authorization, principal, query: "Project Zephyr", mode: "wiki-only" });
     durations.push(performance.now() - started);
     assert.deepEqual(unauthorized, absent);
   }
+  assert.equal(preparedDecisions > 40, true, "fixture must exercise a large restricted catalog");
+  assert.equal(conceptDecisions, preparedDecisions, "query path must not call the concept PDP");
   assert.equal(reads.some((path) => path.endsWith("/policies/nightfall.md")), false);
   assert.equal(durations.every((duration) => duration >= 65), true, `floor was not enforced: ${durations.join(", ")}`);
   for (let index = 0; index < durations.length; index += 2) assert.equal(Math.abs(durations[index] - durations[index + 1]) < 40, true, `timing classes diverged: ${durations.join(", ")}`);

--- a/tests/governance/federation-retrieval.test.mjs
+++ b/tests/governance/federation-retrieval.test.mjs
@@ -129,13 +129,28 @@ test("FEAT-005 traverses hierarchical indexes and retrieves across mounts with q
   assert.deepEqual(await traverseHierarchicalIndex(mounts.find(({ alias }) => alias === "primary").root), [
     "policies/authentication.md", "policies/nightfall.md", "policies/spoof.md", "references/sources/authentication.md"
   ]);
-  const retriever = new FederatedRetriever({ mounts, policy: policy(), now: () => new Date("2026-08-14T15:00:00Z") });
+  const mutatingPolicy = policy(); const authorizeSource = mutatingPolicy.authorizeSource; const sourceInputs = [];
+  mutatingPolicy.authorizeSource = async (input) => {
+    sourceInputs.push(input);
+    for (const mutate of [
+      () => { input.source.resource = "https://attacker.invalid/"; },
+      () => { input.source.access.classification = "public"; },
+      () => { input.concept.access.classification = "public"; },
+      () => { input.mount.id = "attacker"; }
+    ]) try { mutate(); } catch {}
+    return authorizeSource(input);
+  };
+  const retriever = new FederatedRetriever({ mounts, policy: mutatingPolicy, now: () => new Date("2026-08-14T15:00:00Z") });
   const principal = { id: "human:reader" }; const authorization = await retriever.prepareAuthorization({ principal, queryModes: ["wiki-only"] });
   const response = await retriever.search({ authorization, principal, query: "authentication", mode: "wiki-only", includeSources: true, limit: 1 });
   assert.equal(response.status, "ok"); assert.equal(response.results.length, 2); assert.equal(response.citations.length, 2);
   assert.match(response.citations[0].concept, /^kb:\/\/acme\.(?:primary|legacy)@[0-9a-z:-]+\/policies\/authentication$/);
   assert.equal(response.conflicts.length, 2);
   assert.deepEqual(response.results.find(({ id }) => id.startsWith("kb://acme.primary/")).source_citations.map(({ id }) => id), ["auth-source"]);
+  assert.equal(sourceInputs.length > 0, true); assert.equal(sourceInputs.every((input) => Object.isFrozen(input) && Object.isFrozen(input.source)
+    && Object.isFrozen(input.source.access) && Object.isFrozen(input.concept) && Object.isFrozen(input.concept.access) && Object.isFrozen(input.mount)), true);
+  assert.deepEqual(Object.keys(sourceInputs[0]).sort(), ["capability", "concept", "mount", "principal", "queryMode", "source"]);
+  assert.equal(sourceInputs.find(({ source }) => source.id === "auth-source").source.resource, "https://example.invalid/auth");
   const contracts = await createContractValidator(); assert.equal(contracts.validate("retrievalResponse", response).valid, true);
 
   const zeroScoreConflict = await retriever.search({ authorization, principal, query: "phishing-resistant", mode: "wiki-only", limit: 1 });
@@ -184,21 +199,28 @@ test("FEAT-005 authorizes before concept reads and bounds absent/unauthorized re
   catalog.concepts.find(({ id }) => id === "policies/authentication").byte_hash = byteHash(authentication);
   await writeFile(indexPath, index); await writeFile(catalogPath, `${JSON.stringify(catalog)}\n`);
   const { mounts } = await new FederationResolver({ projectRoot: root, now: fixedNow }).resolveProject(project(root));
+  const auditEvents = []; const auditCompletions = [];
+  const slowAudit = (event) => {
+    auditEvents.push(event); const completion = new Promise((resolve) => setTimeout(resolve, event.denied ? 250 : 0)); auditCompletions.push(completion); return completion;
+  };
   const reads = []; let conceptDecisions = 0; let sourceDecisions = 0; const delayedPolicy = policy();
   const authorizeConcept = delayedPolicy.authorizeConcept; const authorizeSource = delayedPolicy.authorizeSource;
   delayedPolicy.authorizeConcept = async (input) => { conceptDecisions += 1; await new Promise((resolve) => setTimeout(resolve, 12)); return authorizeConcept(input); };
   delayedPolicy.authorizeSource = async (input) => { sourceDecisions += 1; await new Promise((resolve) => setTimeout(resolve, 12)); return authorizeSource(input); };
-  const retriever = new FederatedRetriever({ mounts, policy: delayedPolicy, now: () => new Date("2026-08-14T15:00:00Z"), minimumDurationMs: 75,
+  const retriever = new FederatedRetriever({ mounts, policy: delayedPolicy, now: () => new Date("2026-08-14T15:00:00Z"), minimumDurationMs: 75, audit: slowAudit,
     readConcept: async (path) => { reads.push(path); if (path.endsWith("/policies/nightfall.md")) throw new Error("unauthorized body opened"); return readFile(path); } });
   const principal = {}; const authorization = await retriever.prepareAuthorization({ principal, queryModes: ["wiki-only"] });
+  const allAccessState = { ...policyState, classifications: [...policyState.classifications, "restricted"], compartments: [...policyState.compartments, "nightfall"] };
+  const absentRetriever = new FederatedRetriever({ mounts, policy: policy(allAccessState), now: () => new Date("2026-08-14T15:00:00Z"), minimumDurationMs: 75, audit: slowAudit });
+  const absentAuthorization = await absentRetriever.prepareAuthorization({ principal, queryModes: ["wiki-only"] });
   const preparedDecisions = conceptDecisions; const preparedSourceDecisions = sourceDecisions;
   const sourced = await retriever.search({ authorization, principal, query: "authentication", mode: "wiki-only", includeSources: true });
   assert.deepEqual(sourced.results.find(({ id }) => id === "kb://acme.primary/policies/authentication").source_citations.map(({ id }) => id), ["auth-source"]);
   const durations = []; let unauthorized; let absent;
   for (let iteration = 0; iteration < 3; iteration += 1) {
-    let started = performance.now(); unauthorized = await retriever.search({ authorization, principal, query: "Project Nightfall", mode: "wiki-only" });
+    let started = performance.now(); unauthorized = await retriever.search({ authorization, principal, query: "Nightfall", mode: "wiki-only" });
     durations.push(performance.now() - started);
-    started = performance.now(); absent = await retriever.search({ authorization, principal, query: "Project Zephyr", mode: "wiki-only" });
+    started = performance.now(); absent = await absentRetriever.search({ authorization: absentAuthorization, principal, query: "Zephyr", mode: "wiki-only" });
     durations.push(performance.now() - started);
     assert.deepEqual(unauthorized, absent);
   }
@@ -208,7 +230,12 @@ test("FEAT-005 authorizes before concept reads and bounds absent/unauthorized re
   assert.equal(sourceDecisions, preparedSourceDecisions, "query path must not call the source PDP");
   assert.equal(reads.some((path) => path.endsWith("/policies/nightfall.md")), false);
   assert.equal(durations.every((duration) => duration >= 65), true, `floor was not enforced: ${durations.join(", ")}`);
+  assert.equal(durations.every((duration) => duration < 200), true, `protected audit completion leaked into response time: ${durations.join(", ")}`);
   for (let index = 0; index < durations.length; index += 2) assert.equal(Math.abs(durations[index] - durations[index + 1]) < 40, true, `timing classes diverged: ${durations.join(", ")}`);
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.deepEqual(auditEvents.map(({ denied }) => denied).sort(), [false, false, false, true, true, true]);
+  assert.equal(auditEvents.every((event) => Object.isFrozen(event) && Object.isFrozen(event.principal)), true);
+  await Promise.all(auditCompletions);
   assert.deepEqual(Object.keys(absent), ["status", "results", "citations", "conflicts", "warnings", "timing_class"]);
   const contracts = await createContractValidator(); assert.equal(contracts.validate("retrievalResponse", absent).valid, true);
 });

--- a/tests/governance/federation-retrieval.test.mjs
+++ b/tests/governance/federation-retrieval.test.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { execFile as execFileCallback } from "node:child_process";
+import { chmod, cp, lstat, mkdtemp, opendir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import test from "node:test";
+
+import { createContractValidator } from "../../packages/contracts/index.mjs";
+import { FederationError, FederationResolver, routeWrite } from "../../packages/federation/index.mjs";
+import { FederatedRetriever, RetrievalError, traverseHierarchicalIndex } from "../../packages/retrieval/index.mjs";
+
+const execFile = promisify(execFileCallback);
+const fixtures = join(dirname(fileURLToPath(import.meta.url)), "../fixtures/federation");
+const fixedNow = () => "2026-08-14T15:00:00.000Z";
+const policyState = JSON.parse(await readFile(join(fixtures, "policy-state.json"), "utf8"));
+
+function federationCode(code) { return (error) => error instanceof FederationError && error.code === code; }
+function retrievalCode(code) { return (error) => error instanceof RetrievalError && error.code === code; }
+
+async function workspace(context) {
+  const root = await mkdtemp(join(tmpdir(), "kdlc-federation-"));
+  context.after(async () => {
+    async function writable(path) {
+      let metadata; try { metadata = await lstat(path); } catch { return; }
+      if (metadata.isDirectory()) {
+        await chmod(path, 0o700); const directory = await opendir(path);
+        for await (const entry of directory) await writable(join(path, entry.name));
+      } else if (!metadata.isSymbolicLink()) await chmod(path, 0o600);
+    }
+    await writable(root); await rm(root, { recursive: true, force: true });
+  });
+  await cp(join(fixtures, "base-primary"), join(root, "primary"), { recursive: true });
+  await cp(join(fixtures, "base-legacy"), join(root, "legacy-source"), { recursive: true });
+  await execFile("git", ["init", "-q", join(root, "legacy-source")]);
+  await execFile("git", ["-C", join(root, "legacy-source"), "config", "user.name", "Fixture"]);
+  await execFile("git", ["-C", join(root, "legacy-source"), "config", "user.email", "fixture@example.invalid"]);
+  await execFile("git", ["-C", join(root, "legacy-source"), "add", "."]);
+  await execFile("git", ["-C", join(root, "legacy-source"), "commit", "-q", "-m", "fixture"]);
+  return root;
+}
+
+function project(root, extra = []) {
+  return {
+    api_version: "kdlc.dev/v1alpha1", kind: "Project", purpose: "./purpose.md", profile: "base@1",
+    metadata: { name: "federation-test" },
+    knowledge_bases: [
+      { name: "primary", uri: "./primary", mode: "maintain", role: "primary", priority: 100 },
+      { name: "legacy", uri: `git+${pathToFileURL(join(root, "legacy-source")).href}`, ref: "HEAD", mode: "read-only", role: "dependency", priority: 80 },
+      ...extra
+    ]
+  };
+}
+
+test("FEAT-005 resolves local and Git mounts into verified immutable cache and knowledge.lock", async (context) => {
+  const root = await workspace(context); const resolver = new FederationResolver({ projectRoot: root, now: fixedNow });
+  const [resolved, concurrent] = await Promise.all([
+    resolver.resolveProject(project(root)), new FederationResolver({ projectRoot: root, now: fixedNow }).resolveProject(project(root))
+  ]);
+  assert.equal(resolved.mounts.length, 2);
+  assert.match(resolved.mounts[1].resolved_ref, /^[0-9a-f]{40,64}$/);
+  assert.equal(await resolver.verify(resolved.mounts[0]), true);
+  assert.equal((await stat(resolved.mounts[0].root)).mode & 0o222, 0);
+  const lock = JSON.parse(await readFile(join(root, "knowledge.lock"), "utf8"));
+  assert.equal(lock.knowledge_bases.primary.id, "acme.primary");
+  assert.equal(lock.knowledge_bases.legacy.tree_hash, resolved.mounts[1].tree_hash);
+  const contracts = await createContractValidator();
+  assert.equal(contracts.validate("knowledgeLock", lock).valid, true);
+  for (const mount of resolved.mounts) assert.equal(contracts.validate("federationMountResolution", mount).valid, true);
+  assert.deepEqual(concurrent.mounts.map(({ root: cache }) => cache), resolved.mounts.map(({ root: cache }) => cache));
+});
+
+test("FEAT-005 rejects duplicate stable IDs, cache drift, unsafe Git entries, and mutable tree reuse", async (context) => {
+  const root = await workspace(context); const resolver = new FederationResolver({ projectRoot: root, now: fixedNow });
+  await assert.rejects(resolver.resolveProject(project(root, [
+    { name: "duplicate", uri: "./primary", mode: "read-only", role: "dependency", priority: 1 }
+  ])), federationCode("KDLC_DUPLICATE_KB_ID"));
+
+  const resolved = await resolver.resolveProject(project(root)); const primary = resolved.mounts.find(({ alias }) => alias === "primary");
+  const concept = join(primary.root, "policies/authentication.md");
+  await chmod(primary.root, 0o755); await chmod(join(primary.root, "policies"), 0o755); await chmod(concept, 0o644);
+  await writeFile(concept, `${await readFile(concept, "utf8")}\ndrift\n`);
+  await assert.rejects(resolver.verify(primary), federationCode("KDLC_CACHE_DRIFT"));
+  await assert.rejects(new FederatedRetriever({ mounts: resolved.mounts, policy: policy(), now: () => new Date(fixedNow()) })
+    .search({ principal: {}, query: "authentication" }), retrievalCode("KDLC_MOUNT_INTEGRITY"));
+  await assert.rejects(resolver.resolveMount(project(root).knowledge_bases[0]), federationCode("KDLC_CACHE_DRIFT"));
+  await assert.rejects(stat(primary.root), (error) => error.code === "ENOENT");
+
+  await cp(join(fixtures, "base-primary"), join(root, "unsafe-local"), { recursive: true });
+  await symlink(join(root, "primary", "index.md"), join(root, "unsafe-local", "escape.md"));
+  await assert.rejects(resolver.resolveMount({ name: "unsafe", uri: "./unsafe-local", mode: "read-only" }), federationCode("KDLC_FEDERATION_SYMLINK"));
+
+  const oldGit = resolved.mounts.find(({ alias }) => alias === "legacy");
+  await writeFile(join(root, "legacy-source", "new.md"), "---\ntype: Reference\n---\nnew\n");
+  await execFile("git", ["-C", join(root, "legacy-source"), "add", "."]); await execFile("git", ["-C", join(root, "legacy-source"), "commit", "-q", "-m", "next"]);
+  const refreshed = await new FederationResolver({ projectRoot: root, now: fixedNow }).resolveMount(project(root).knowledge_bases[1]);
+  assert.notEqual(refreshed.resolved_ref, oldGit.resolved_ref); assert.notEqual(refreshed.root, oldGit.root);
+
+  await symlink("knowledge-base.yaml", join(root, "legacy-source", "escape"));
+  await execFile("git", ["-C", join(root, "legacy-source"), "add", "escape"]); await execFile("git", ["-C", join(root, "legacy-source"), "commit", "-q", "-m", "unsafe symlink"]);
+  await assert.rejects(new FederationResolver({ projectRoot: root, now: fixedNow }).resolveMount(project(root).knowledge_bases[1]), federationCode("KDLC_GIT_ENTRY"));
+});
+
+function policy(state = policyState) {
+  const clearance = new Set(state.classifications); const compartments = new Set(state.compartments);
+  const allows = (access = { classification: "internal" }) => clearance.has(access.classification)
+    && (access.compartments ?? []).every((compartment) => compartments.has(compartment));
+  return {
+    authorizeMount: async ({ mount, queryMode }) => state.query_modes.includes(queryMode) && allows(mount.access),
+    authorizeConcept: async ({ concept }) => allows(concept.access ?? undefined),
+    authorizeSource: async ({ source }) => allows(source.access ?? undefined)
+  };
+}
+
+test("FEAT-005 traverses hierarchical indexes and retrieves across mounts with qualified conflicts", async (context) => {
+  const root = await workspace(context); const { mounts } = await new FederationResolver({ projectRoot: root, now: fixedNow }).resolveProject(project(root));
+  assert.deepEqual(await traverseHierarchicalIndex(mounts.find(({ alias }) => alias === "primary").root), [
+    "policies/authentication.md", "policies/nightfall.md", "policies/spoof.md", "references/sources/authentication.md"
+  ]);
+  const retriever = new FederatedRetriever({ mounts, policy: policy(), now: () => new Date("2026-08-14T15:00:00Z") });
+  const response = await retriever.search({ principal: { id: "human:reader" }, query: "authentication", mode: "wiki-only", includeSources: true, limit: 1 });
+  assert.equal(response.status, "ok"); assert.equal(response.results.length, 2); assert.equal(response.citations.length, 2);
+  assert.match(response.citations[0].concept, /^kb:\/\/acme\.(?:primary|legacy)@[0-9a-z:-]+\/policies\/authentication$/);
+  assert.equal(response.conflicts.length, 2);
+  assert.deepEqual(response.results.find(({ id }) => id.startsWith("kb://acme.primary/")).source_citations.map(({ id }) => id), ["auth-source"]);
+  const contracts = await createContractValidator(); assert.equal(contracts.validate("retrievalResponse", response).valid, true);
+});
+
+test("FEAT-005 applies query-mode, trust, freshness, and access filters before disclosure", async (context) => {
+  const root = await workspace(context); const { mounts } = await new FederationResolver({ projectRoot: root, now: fixedNow }).resolveProject(project(root));
+  const retriever = new FederatedRetriever({ mounts, policy: policy(), now: () => new Date("2026-08-14T15:00:00Z") });
+  const trusted = await retriever.search({ principal: {}, query: "authentication", mode: "trusted-only" });
+  assert.deepEqual(trusted.results.map(({ id }) => id), ["kb://acme.primary/policies/authentication"]);
+  assert.equal((await retriever.search({ principal: {}, query: "spoofed verification", mode: "trusted-only" })).status, "not_found");
+  const sources = await retriever.search({ principal: {}, query: "authentication", mode: "sources-only", staleBehavior: "warn" });
+  assert.equal(sources.results.length, 1); assert.equal(sources.results[0].freshness, "stale"); assert.equal(sources.warnings.length, 1);
+  const fresh = await retriever.search({ principal: {}, query: "authentication", mode: "fresh-only" });
+  assert.equal(fresh.results.some(({ id }) => id.includes("references/sources")), false);
+  await assert.rejects(retriever.search({ principal: {}, query: "authentication", mode: "vector-only" }), retrievalCode("KDLC_QUERY_MODE"));
+});
+
+test("FEAT-005 makes absent and unauthorized results externally indistinguishable with equal timing floor", async (context) => {
+  const root = await workspace(context); const { mounts } = await new FederationResolver({ projectRoot: root, now: fixedNow }).resolveProject(project(root));
+  const waits = []; const retriever = new FederatedRetriever({ mounts, policy: policy(), now: () => new Date("2026-08-14T15:00:00Z"),
+    minimumDurationMs: 25, monotonic: () => 0, wait: async (duration) => { waits.push(duration); } });
+  const unauthorized = await retriever.search({ principal: {}, query: "Project Nightfall", mode: "wiki-only" });
+  const absent = await retriever.search({ principal: {}, query: "Project Zephyr", mode: "wiki-only" });
+  assert.deepEqual(unauthorized, absent); assert.deepEqual(waits, [25, 25]);
+  assert.deepEqual(Object.keys(absent), ["status", "results", "citations", "conflicts", "warnings", "timing_class"]);
+  const contracts = await createContractValidator(); assert.equal(contracts.validate("retrievalResponse", absent).valid, true);
+});
+
+test("FEAT-005 write routing preserves dependency bases and never uses retrieval priority", async (context) => {
+  const root = await workspace(context); const { mounts } = await new FederationResolver({ projectRoot: root, now: fixedNow }).resolveProject(project(root));
+  const before = await readFile(join(mounts.find(({ alias }) => alias === "legacy").root, "policies/authentication.md"));
+  assert.deepEqual(routeWrite({ mounts, explicitTarget: "legacy" }), { action: "proposal", target: "legacy", knowledge_base_id: "acme.legacy" });
+  assert.deepEqual(routeWrite({ mounts, conceptType: "Policy", routing: { by_type: { Policy: "primary" } } }), { action: "write", target: "primary", knowledge_base_id: "acme.primary" });
+  assert.deepEqual(await readFile(join(mounts.find(({ alias }) => alias === "legacy").root, "policies/authentication.md")), before);
+  assert.throws(() => routeWrite({ mounts, routing: {} }), federationCode("KDLC_ROUTE_AMBIGUOUS"));
+});

--- a/tests/governance/federation-retrieval.test.mjs
+++ b/tests/governance/federation-retrieval.test.mjs
@@ -82,11 +82,11 @@ test("FEAT-005 rejects duplicate stable IDs, cache drift, unsafe Git entries, an
 
   const resolved = await resolver.resolveProject(project(root)); const primary = resolved.mounts.find(({ alias }) => alias === "primary");
   const concept = join(primary.root, "policies/authentication.md");
+  const driftRetriever = new FederatedRetriever({ mounts: resolved.mounts, policy: policy(), now: () => new Date(fixedNow()) });
+  const driftAuthorization = await driftRetriever.prepareAuthorization({ principal: {}, queryModes: ["wiki-only"] });
   await chmod(primary.root, 0o755); await chmod(join(primary.root, "policies"), 0o755); await chmod(concept, 0o644);
   await writeFile(concept, `${await readFile(concept, "utf8")}\ndrift\n`);
   await assert.rejects(resolver.verify(primary), federationCode("KDLC_CACHE_DRIFT"));
-  const driftRetriever = new FederatedRetriever({ mounts: resolved.mounts, policy: policy(), now: () => new Date(fixedNow()) });
-  const driftAuthorization = await driftRetriever.prepareAuthorization({ principal: {}, queryModes: ["wiki-only"] });
   await assert.rejects(driftRetriever.search({ authorization: driftAuthorization, principal: {}, query: "authentication" }), retrievalCode("KDLC_MOUNT_INTEGRITY"));
   await assert.rejects(resolver.resolveMount(project(root).knowledge_bases[0]), federationCode("KDLC_CACHE_DRIFT"));
   await assert.rejects(stat(primary.root), (error) => error.code === "ENOENT");
@@ -159,6 +159,13 @@ test("FEAT-005 applies query-mode, trust, freshness, and access filters before d
   assert.equal(fresh.results.some(({ id }) => id.includes("references/sources")), false);
   await assert.rejects(retriever.search({ principal, query: "authentication", mode: "wiki-only" }), retrievalCode("KDLC_AUTHORIZATION_SNAPSHOT_REQUIRED"));
   await assert.rejects(retriever.search({ principal: {}, query: "authentication", mode: "vector-only" }), retrievalCode("KDLC_QUERY_MODE"));
+
+  let authorizationTime = 100;
+  const expiring = new FederatedRetriever({ mounts, policy: policy(), now: () => new Date("2026-08-14T15:00:00Z"), authorizationTtlMs: 10,
+    authorizationMonotonic: () => authorizationTime });
+  const expiringAuthorization = await expiring.prepareAuthorization({ principal, queryModes: ["wiki-only"] });
+  authorizationTime = 110;
+  await assert.rejects(expiring.search({ authorization: expiringAuthorization, principal, query: "authentication" }), retrievalCode("KDLC_AUTHORIZATION_SNAPSHOT_REQUIRED"));
 });
 
 test("FEAT-005 authorizes before concept reads and bounds absent/unauthorized response timing", async (context) => {
@@ -169,13 +176,24 @@ test("FEAT-005 authorizes before concept reads and bounds absent/unauthorized re
     await writeFile(join(root, "primary", "policies", `${name}.md`), body); index += `* [Restricted ${number}](${name}.md)\n`;
     catalog.concepts.push({ id: `policies/${name}`, path: `policies/${name}.md`, byte_hash: byteHash(body), access: { classification: "restricted", compartments: ["nightfall"] } });
   }
+  const authenticationPath = join(root, "primary", "policies", "authentication.md");
+  let authentication = await readFile(authenticationPath, "utf8");
+  authentication = authentication.replace("---\nAuthentication must use", `${Array.from({ length: 40 }, (_, number) =>
+    `  - { id: denied-${String(number).padStart(2, "0")}, resource: "https://restricted.example.invalid/${number}", access: { classification: restricted, compartments: [nightfall] } }`).join("\n")}\n---\nAuthentication must use`);
+  await writeFile(authenticationPath, authentication);
+  catalog.concepts.find(({ id }) => id === "policies/authentication").byte_hash = byteHash(authentication);
   await writeFile(indexPath, index); await writeFile(catalogPath, `${JSON.stringify(catalog)}\n`);
   const { mounts } = await new FederationResolver({ projectRoot: root, now: fixedNow }).resolveProject(project(root));
-  const reads = []; let conceptDecisions = 0; const delayedPolicy = policy(); const authorizeConcept = delayedPolicy.authorizeConcept;
+  const reads = []; let conceptDecisions = 0; let sourceDecisions = 0; const delayedPolicy = policy();
+  const authorizeConcept = delayedPolicy.authorizeConcept; const authorizeSource = delayedPolicy.authorizeSource;
   delayedPolicy.authorizeConcept = async (input) => { conceptDecisions += 1; await new Promise((resolve) => setTimeout(resolve, 12)); return authorizeConcept(input); };
+  delayedPolicy.authorizeSource = async (input) => { sourceDecisions += 1; await new Promise((resolve) => setTimeout(resolve, 12)); return authorizeSource(input); };
   const retriever = new FederatedRetriever({ mounts, policy: delayedPolicy, now: () => new Date("2026-08-14T15:00:00Z"), minimumDurationMs: 75,
     readConcept: async (path) => { reads.push(path); if (path.endsWith("/policies/nightfall.md")) throw new Error("unauthorized body opened"); return readFile(path); } });
-  const principal = {}; const authorization = await retriever.prepareAuthorization({ principal, queryModes: ["wiki-only"] }); const preparedDecisions = conceptDecisions;
+  const principal = {}; const authorization = await retriever.prepareAuthorization({ principal, queryModes: ["wiki-only"] });
+  const preparedDecisions = conceptDecisions; const preparedSourceDecisions = sourceDecisions;
+  const sourced = await retriever.search({ authorization, principal, query: "authentication", mode: "wiki-only", includeSources: true });
+  assert.deepEqual(sourced.results.find(({ id }) => id === "kb://acme.primary/policies/authentication").source_citations.map(({ id }) => id), ["auth-source"]);
   const durations = []; let unauthorized; let absent;
   for (let iteration = 0; iteration < 3; iteration += 1) {
     let started = performance.now(); unauthorized = await retriever.search({ authorization, principal, query: "Project Nightfall", mode: "wiki-only" });
@@ -185,7 +203,9 @@ test("FEAT-005 authorizes before concept reads and bounds absent/unauthorized re
     assert.deepEqual(unauthorized, absent);
   }
   assert.equal(preparedDecisions > 40, true, "fixture must exercise a large restricted catalog");
+  assert.equal(preparedSourceDecisions > 40, true, "fixture must exercise a large restricted source list");
   assert.equal(conceptDecisions, preparedDecisions, "query path must not call the concept PDP");
+  assert.equal(sourceDecisions, preparedSourceDecisions, "query path must not call the source PDP");
   assert.equal(reads.some((path) => path.endsWith("/policies/nightfall.md")), false);
   assert.equal(durations.every((duration) => duration >= 65), true, `floor was not enforced: ${durations.join(", ")}`);
   for (let index = 0; index < durations.length; index += 2) assert.equal(Math.abs(durations[index] - durations[index + 1]) < 40, true, `timing classes diverged: ${durations.join(", ")}`);


### PR DESCRIPTION
## Outcome

Implements FEAT-005 verified immutable local and Git mounts, serialized content-addressed cache and knowledge.lock output, duplicate/drift quarantine, hierarchical lexical retrieval, pre-disclosure authorization/trust/freshness/query-mode filters, qualified citations and conflict expansion, read-only/propose routing, and matched absent-versus-denied response envelopes.

Review fixes add a package-integrity-bound retrieval catalog. Mount materialization verifies each catalog access label (including policy_ref) and byte hash against its concept. Recorded conflict partners are expanded from all authorized/filter-eligible concepts after ranking, including lexical-score-zero partners beyond the requested limit.

At 744aac7, mount/index/concept/source PDP work and authorized concept parsing occur only during an opaque, principal- and retriever-bound, short-lived pre-query authorization snapshot. The snapshot retains only policy-authorized source citation metadata. Source policy callbacks receive independent minimal, deeply frozen JSON views; parsed concepts, frontmatter, metadata, and citations are independently deeply frozen before storage. Search performs no concept or source PDP calls, no restricted catalog traversal, and no denied-source processing. Snapshot validity fails closed at the exact expiration boundary.

Protected empty-result audit uses an immutable captured event dispatched after the common response-time floor; requester completion does not await audit completion. The adversarial tests include 40 restricted concepts and 40 denied sources, realistic delayed concept/source PDPs, a mutating source PDP, and a 250 ms denied-audit callback. They verify zero query-path decisions/reads for denied entries, mutation-resistant allowed citations, only the allowed citation is disclosed, and repeated real-clock absent versus unauthorized responses remain in the same bounded class.

The branch is rebased on main 1a9ec2d and preserves the merged FEAT-003 and FEAT-004 contracts, traceability, package lock, and lifecycle contention fixes.

Closes #7

## Traceability

- Requirement IDs: FEAT-005
- Specification sections: §18-§20, §21, §27.3, §34 Slice 5, §35.8-§35.9
- Traceability index updated: yes

## Gate evidence

- [x] Requirement, dependencies, and risks recorded in issue #7.
- [x] Local/Git snapshot, cache drift, duplicate ID, path/symlink, catalog downgrade, authorization-before-read, immutable PDP/snapshot boundaries, nondisclosure timing/count/PDP/audit isolation, exact snapshot expiry, zero-score conflict, citation, and routing fixtures pass.
- [x] Final independent review completed with no blocking findings.

Commands and results:

```text
npm test on Node 24: 97 passed, 0 failed
combined focused FEAT-001/003/004/005 tests: 33 passed, 0 failed
focused federation retrieval tests: 7 passed, 0 failed
npm audit --audit-level=high: 0 vulnerabilities
git diff --check: clean
```

## Risk and rollback

The catalog is package metadata bound by the immutable tree hash and is validated against concept bytes/access labels during trusted mount materialization. Authorization snapshots are opaque, fail closed on principal/retriever/mode mismatch, expire after at most five minutes, and bind deeply frozen allowed source citations before request execution. Protected audit delivery is asynchronous and audit callback failures do not alter requester-visible retrieval results. Unauthorized per-concept corruption is not surfaced during a request; an authorized access or explicit mount verification fails closed. Rollback is a revert of the five FEAT-005 commits.

## MVP boundaries

Proposal persistence is delegated to FEAT-004. Vector, graph, transitive, and MCP mounts remain post-MVP. An offline reopen API for an already locked but unreachable Git remote is not claimed by this slice.




