### PR TITLE
fix: tolerate audited writer contention (#4 FEAT-002)

### DIFF
--- a/packages/lifecycle/src/store.mjs
+++ b/packages/lifecycle/src/store.mjs
@@ -145,7 +145,7 @@ export class NodeFileStore {
     catch (error) { if (error?.code !== "EEXIST") throw error; }
   }
 
-  async withMutex(relativePath, { owner, clock, leaseMs = 30_000, timeoutMs = 2_000, retryMs = 2 }, action) {
+  async withMutex(relativePath, { owner, clock, leaseMs = 30_000, timeoutMs = 10_000, retryMs = 2 }, action) {
     if (!owner || !clock?.millis) throw invalid("Filesystem mutex requires owner and clock");
     const started = Date.now();
     const leasePath = `${relativePath}/owner.json`;


### PR DESCRIPTION
## Outcome

Raises the default coordinated filesystem mutex acquisition budget from two seconds to ten seconds so valid serialized audit writers do not fail under slower CI contention. Safety-first live-owner exclusion, heartbeat, fencing, and dead-owner recovery semantics are unchanged.

Closes #4

## Traceability

- Requirement IDs: FEAT-002
- Specification sections: §16-§17, §28, §35.12

Commands and results:

```text
focused lifecycle concurrency suite: passed 5 consecutive runs
npm test: 72 passed, 0 failed
npm audit: 0 vulnerabilities
git diff --check: clean
```

- [x] Final independent review completed with no blocking findings.
