### PR TITLE
chore: refresh dependency and non-protected action runtimes

### DIFF
--- a/.github/workflows/candidate-tests.yml
+++ b/.github/workflows/candidate-tests.yml
@@ -12,7 +12,7 @@ jobs:
     name: Candidate tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false

--- a/.github/workflows/candidate-tests.yml
+++ b/.github/workflows/candidate-tests.yml
@@ -12,7 +12,7 @@ jobs:
     name: Candidate tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,15 +19,15 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: javascript-typescript
           queries: security-extended
       - name: Analyze
-        uses: github/codeql-action/analyze@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: /language:javascript-typescript

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,11 +11,11 @@ jobs:
     name: Dependency review
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Review dependency changes
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: moderate
           license-check: true

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -19,7 +19,7 @@ jobs:
       statuses: write
     steps:
       - name: Check out trusted validator
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.base.sha }}
           path: trusted
@@ -30,7 +30,7 @@ jobs:
       - run: npm ci --ignore-scripts --prefix trusted
       - name: Check out candidate as untrusted data
         if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: candidate
@@ -70,7 +70,7 @@ jobs:
       statuses: write
     steps:
       - name: Check out trusted validator
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: trusted
@@ -80,7 +80,7 @@ jobs:
           node-version: 22
       - run: npm ci --ignore-scripts --prefix trusted
       - name: Check out candidate as untrusted data
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/secret-history.yml
+++ b/.github/workflows/secret-history.yml
@@ -16,7 +16,7 @@ jobs:
     name: Secret history scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -16,7 +16,7 @@ jobs:
     name: Supply-chain verification
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,11 +2,11 @@
 
 This inventory is generated after a clean integrity-checked `npm ci --ignore-scripts` from the required installed dependency graph. Platform-specific optional packages are excluded from this portable SBOM and remain pinned and audited through `package-lock.json`. K-DLC is licensed under MIT; dependencies remain under their respective licenses. Installed tree, manifest, and license-file hashes bind the listed evidence to the verified bytes. Where a package ships no license or notice file, the declared license is explicitly sourced from its installed `package.json` metadata.
 
-Inventory hash: `sha256:bdb38b151644e33c01fd49dd9516a13ef727440bf866d9f3b15e9c320ebab406`
+Inventory hash: `sha256:c5f6f75b5c6817e3483738e99fffd196017c6a6930ae5d423af29d35024cf185`
 
 | Package | Version | Scope | License | Installed tree | Installed manifest | Locked source |
 | --- | --- | --- | --- | --- | --- | --- |
-| `acorn` | `8.15.0` | `runtime` | `MIT` | `sha256:3173ae18cf080076d1348626dbb005661101e2d1b8c0667f8abf865f06210ee0` | `sha256:9e422c8225c9cc4c774e9a9392d0ecac7f766b46122ef2db99db0fc4bbedc247` | [npm tarball](https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz) |
+| `acorn` | `8.18.0` | `runtime` | `MIT` | `sha256:53f8832f4ab27c0bf40e47c7cd3e9101c5424ebe67cd9e91c78377eaab4318ce` | `sha256:5c1ed7259579a7899b303f514b0194adcb9fe474fc7d136a84c6a45f10eefc84` | [npm tarball](https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz) |
 | `ajv` | `8.20.0` | `runtime` | `MIT` | `sha256:e859ebf1b94be121a5bfaa154d15b34b32e0cf1badb3d32c8d2aec9ca1bca18d` | `sha256:1f9033ee5a6515e7d76938b7072941862d1ed228a6879cc7fe10cdeb75107989` | [npm tarball](https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz) |
 | `ajv-formats` | `3.0.1` | `runtime` | `MIT` | `sha256:cdf999e448d8ecd3d0caae0d90c751376349308c4b2a9fe1535de521cc578556` | `sha256:402fb4bcfa457f0226813f3976ac42839dd619907c075c108efba8600d7edb69` | [npm tarball](https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz) |
 | `canonicalize` | `4.0.0` | `runtime` | `Apache-2.0` | `sha256:a40fe8c99d8438142d7f02877361804fd1f9b9420ce42a2b45c0f34c6a9e2dca` | `sha256:b4fe69cd7668c761bc1f0a6c41fcd3d4e53bc3c2d280b5d789fe5e6a6c6505d0` | [npm tarball](https://registry.npmjs.org/canonicalize/-/canonicalize-4.0.0.tgz) |
@@ -20,6 +20,6 @@ Inventory hash: `sha256:bdb38b151644e33c01fd49dd9516a13ef727440bf866d9f3b15e9c32
 | `pdfjs-dist` | `6.2.108` | `runtime` | `Apache-2.0` | `sha256:a1269590ee95c9da6984d8f1492deaa0a98f634feb8a5a4c8a4be83586585bcd` | `sha256:d7918934bf0ef5b18beed1bd2d9b49a04447de445c171305a2de082ccee369ed` | [npm tarball](https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.2.108.tgz) |
 | `require-from-string` | `2.0.2` | `runtime` | `MIT` | `sha256:13c3624546c861ae673708442112b8dc2edddaace91e44ef65b2fc35932ed1ba` | `sha256:c0002f7d4c7d7e2a885cf0f97226344902417c3a0980f2beca41962d2bc1f6d8` | [npm tarball](https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz) |
 | `saxes` | `6.0.0` | `runtime` | `ISC` | `sha256:d6e427a18a7e78dbed1382d0df9379b8f5ac61116baef0287d5849b0b0eba2e1` | `sha256:32052572b41c2a890ed0854798c48454cc5991dcaafe5fb1718a4253046acfd3` | [npm tarball](https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz) |
-| `semver` | `7.7.2` | `runtime` | `ISC` | `sha256:aa9c0894b635f1fb5da642b1871976becb3c67d08f09b736829b675efce12e21` | `sha256:bf2e091359d5870257cc8287a268e001bfb39abf19275f382276efe3c7785a4f` | [npm tarball](https://registry.npmjs.org/semver/-/semver-7.7.2.tgz) |
+| `semver` | `7.8.5` | `runtime` | `ISC` | `sha256:d41db7e69f43c2f3b8ef277354787bd6adea6128b38d4741a9343ef4ecedadb5` | `sha256:7c94cb7f2a53c27b20d76386ec144c062894dbcc909cfabd0f728c37874b1776` | [npm tarball](https://registry.npmjs.org/semver/-/semver-7.8.5.tgz) |
 | `xmlchars` | `2.2.0` | `runtime` | `MIT` | `sha256:b6b7dd6cd0bd01094fb1da3b602b99763d3faf056cb42c7971c8eacc9f31bb44` | `sha256:a91c0b20003ff9399dde1de8c59681f1b6901c6fb1aac71780a3a876dc548583` | [npm tarball](https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz) |
 | `yaml` | `2.9.0` | `runtime` | `ISC` | `sha256:7bb54286b2425f5863376e81a083dce51c713bcbd776bdab39b769e34cc92a7f` | `sha256:20b8b197cbd10dad245d45e463dfe58e4c8c25a47e24bc4256ad9ab58bf35683` | [npm tarball](https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz) |

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -16,5 +16,5 @@
   "pending_requirements": [
     {"id": "REL-001", "issue": 10, "reason": "Statistical evaluation, final artifact/version agreement, external protections, and independent release verification remain pending.", "release_blocking": true}
   ],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:d4479fe02f7d1d38c18133b1519b28c282b922b36f668ef7dfdf7049f6fddae5"},{"path":"docs/traceability.json","sha256":"sha256:fbf57223d1172c97476d9f31afdf2f3c0f9400e4af066496d0df286fd4654257"},{"path":"docs/release-readiness.md","sha256":"sha256:a4eaa15544f02b72e4a50dbc50bb8b6a5ad91c6e07ac8dce19985f936f5c4652"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:d4479fe02f7d1d38c18133b1519b28c282b922b36f668ef7dfdf7049f6fddae5"},{"path":"docs/traceability.json","sha256":"sha256:ab3f2a0d340d3d7a9fa6fe2510987a22e04262f12e7b98deb293db3fb7c5e10b"},{"path":"docs/release-readiness.md","sha256":"sha256:a4eaa15544f02b72e4a50dbc50bb8b6a5ad91c6e07ac8dce19985f936f5c4652"}]
 }

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -16,5 +16,5 @@
   "pending_requirements": [
     {"id": "REL-001", "issue": 10, "reason": "Statistical evaluation, final artifact/version agreement, external protections, and independent release verification remain pending.", "release_blocking": true}
   ],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:d4479fe02f7d1d38c18133b1519b28c282b922b36f668ef7dfdf7049f6fddae5"},{"path":"docs/traceability.json","sha256":"sha256:ab3f2a0d340d3d7a9fa6fe2510987a22e04262f12e7b98deb293db3fb7c5e10b"},{"path":"docs/release-readiness.md","sha256":"sha256:a4eaa15544f02b72e4a50dbc50bb8b6a5ad91c6e07ac8dce19985f936f5c4652"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:d4479fe02f7d1d38c18133b1519b28c282b922b36f668ef7dfdf7049f6fddae5"},{"path":"docs/traceability.json","sha256":"sha256:47792ca8660da8d387b8c62bce57533109451634021e0ff80e02ff6b559247ff"},{"path":"docs/release-readiness.md","sha256":"sha256:a4eaa15544f02b72e4a50dbc50bb8b6a5ad91c6e07ac8dce19985f936f5c4652"}]
 }

--- a/docs/supply-chain/sbom.spdx.json
+++ b/docs/supply-chain/sbom.spdx.json
@@ -3,7 +3,7 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "knowledge-dlc-0.0.0-private",
-  "documentNamespace": "https://github.com/aithinkers/knowledge-dlc/sbom/c78303ec1bbe69daf3867d2901f345514cf8e2785b18c4a8e8bec71d4e7903a7",
+  "documentNamespace": "https://github.com/aithinkers/knowledge-dlc/sbom/39c5ddf336cf0a0b454068fcbf7e9befa1a584184469b08b553681d5d0091938",
   "creationInfo": {
     "created": "1970-01-01T00:00:00Z",
     "creators": [
@@ -25,17 +25,17 @@
       "copyrightText": "Copyright (c) 2026 AIThinkers"
     },
     {
-      "SPDXID": "SPDXRef-Package-a6b193ff0df9277b6807",
+      "SPDXID": "SPDXRef-Package-c7901d4af178944446ba",
       "name": "acorn",
-      "versionInfo": "8.15.0",
-      "downloadLocation": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "versionInfo": "8.18.0",
+      "downloadLocation": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
       "filesAnalyzed": false,
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "MIT",
       "checksums": [
         {
           "algorithm": "SHA512",
-          "checksumValue": "359c896ab05f2fb9d6c08abe1432fa669ff21c485e3cc3679c9d32dea7e2782ae636f61cb7cbafb62578d54be549ee9aa407e4d1f63515b5b1f8dc1f9a9bed4e"
+          "checksumValue": "946abef72af5fc6b8059a558207463befc921b9ff855f288bc2f045b14ad3dd70387f29aec51b7b703fabf8779064adabd48a584802c1b8423f37b74d8b5943d"
         }
       ],
       "primaryPackagePurpose": "LIBRARY",
@@ -44,12 +44,12 @@
         {
           "referenceCategory": "OTHER",
           "referenceType": "kdlc:installed-manifest-sha256",
-          "referenceLocator": "sha256:9e422c8225c9cc4c774e9a9392d0ecac7f766b46122ef2db99db0fc4bbedc247"
+          "referenceLocator": "sha256:5c1ed7259579a7899b303f514b0194adcb9fe474fc7d136a84c6a45f10eefc84"
         },
         {
           "referenceCategory": "OTHER",
           "referenceType": "kdlc:installed-tree-sha256",
-          "referenceLocator": "sha256:3173ae18cf080076d1348626dbb005661101e2d1b8c0667f8abf865f06210ee0"
+          "referenceLocator": "sha256:53f8832f4ab27c0bf40e47c7cd3e9101c5424ebe67cd9e91c78377eaab4318ce"
         },
         {
           "referenceCategory": "OTHER",
@@ -501,17 +501,17 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-Package-9820574a08f66349702b",
+      "SPDXID": "SPDXRef-Package-82a86616e50ded792532",
       "name": "semver",
-      "versionInfo": "7.7.2",
-      "downloadLocation": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "versionInfo": "7.8.5",
+      "downloadLocation": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "filesAnalyzed": false,
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "ISC",
       "checksums": [
         {
           "algorithm": "SHA512",
-          "checksumValue": "445d05c3eacee4031ff4c0326915c8e005745258f994c1ea571c5d4a08956e2c52097a049a65ff8e4d02b89c38fb74aaae860ef55a1487e1dcb898afbed25e98"
+          "checksumValue": "63bfca0ec6fc2e3a28669c1aa86cae94ee8342592c8029dc7211c693eb19218e1206f52870c044147e54af57c8e1d57e26f974c3a723bee71a222e34a6e462a0"
         }
       ],
       "primaryPackagePurpose": "LIBRARY",
@@ -520,12 +520,12 @@
         {
           "referenceCategory": "OTHER",
           "referenceType": "kdlc:installed-manifest-sha256",
-          "referenceLocator": "sha256:bf2e091359d5870257cc8287a268e001bfb39abf19275f382276efe3c7785a4f"
+          "referenceLocator": "sha256:7c94cb7f2a53c27b20d76386ec144c062894dbcc909cfabd0f728c37874b1776"
         },
         {
           "referenceCategory": "OTHER",
           "referenceType": "kdlc:installed-tree-sha256",
-          "referenceLocator": "sha256:aa9c0894b635f1fb5da642b1871976becb3c67d08f09b736829b675efce12e21"
+          "referenceLocator": "sha256:d41db7e69f43c2f3b8ef277354787bd6adea6128b38d4741a9343ef4ecedadb5"
         },
         {
           "referenceCategory": "OTHER",
@@ -607,7 +607,7 @@
     {
       "spdxElementId": "SPDXRef-Root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-Package-a6b193ff0df9277b6807"
+      "relatedSpdxElement": "SPDXRef-Package-c7901d4af178944446ba"
     },
     {
       "spdxElementId": "SPDXRef-Root",
@@ -647,7 +647,7 @@
     {
       "spdxElementId": "SPDXRef-Root",
       "relationshipType": "DEPENDS_ON",
-      "relatedSpdxElement": "SPDXRef-Package-9820574a08f66349702b"
+      "relatedSpdxElement": "SPDXRef-Package-82a86616e50ded792532"
     },
     {
       "spdxElementId": "SPDXRef-Root",

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -213,7 +213,6 @@
       "status": "in-progress",
       "evidence": {
         "implementation": [
-          ".github/workflows/candidate-tests.yml",
           ".github/workflows/codeql.yml",
           ".github/workflows/dependency-review.yml",
           ".github/workflows/governance.yml",

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -204,6 +204,29 @@
         ],
         "tests": ["tests/governance/release-evidence.test.mjs"]
       }
+    },
+    {
+      "id": "REQ-SUPPLY-001",
+      "title": "Refresh dependency and GitHub Action runtimes before release",
+      "issue": 36,
+      "specification_sections": ["32", "35", "36"],
+      "status": "in-progress",
+      "evidence": {
+        "implementation": [
+          ".github/workflows/candidate-tests.yml",
+          ".github/workflows/codeql.yml",
+          ".github/workflows/dependency-review.yml",
+          ".github/workflows/governance.yml",
+          ".github/workflows/secret-history.yml",
+          ".github/workflows/supply-chain.yml",
+          "package.json",
+          "package-lock.json",
+          "THIRD_PARTY_NOTICES.md",
+          "docs/supply-chain/sbom.spdx.json",
+          "security/npm-package-files.json"
+        ],
+        "tests": ["tests/governance/extensions.test.mjs", "tests/governance/release-readiness.test.mjs"]
+      }
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-private",
       "license": "MIT",
       "dependencies": {
-        "acorn": "8.15.0",
+        "acorn": "8.18.0",
         "ajv-formats": "3.0.1",
         "canonicalize": "4.0.0",
         "csv-parse": "7.0.2",
@@ -17,8 +17,11 @@
         "gifuct-js": "2.1.2",
         "pdfjs-dist": "6.2.108",
         "saxes": "6.0.0",
-        "semver": "7.7.2",
+        "semver": "7.8.5",
         "yaml": "2.9.0"
+      },
+      "bin": {
+        "kdlc": "packages/cli/bin.mjs"
       },
       "devDependencies": {
         "ajv": "8.20.0"
@@ -279,9 +282,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -424,9 +427,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test": "npm run check:governance && npm run test:governance"
   },
   "dependencies": {
-    "acorn": "8.15.0",
+    "acorn": "8.18.0",
     "ajv-formats": "3.0.1",
     "canonicalize": "4.0.0",
     "csv-parse": "7.0.2",
@@ -63,7 +63,7 @@
     "gifuct-js": "2.1.2",
     "pdfjs-dist": "6.2.108",
     "saxes": "6.0.0",
-    "semver": "7.7.2",
+    "semver": "7.8.5",
     "yaml": "2.9.0"
   },
   "devDependencies": {

--- a/tests/governance/extensions.test.mjs
+++ b/tests/governance/extensions.test.mjs
@@ -89,6 +89,24 @@ test("FEAT-007 scanner derives signed inventory from bytes and rejects hidden im
   await expectCodeAsync("KDLC_EXTENSION_PERMISSION_UNDERREPORTED", () => scanner.scan(packageRoot("underreported")));
 });
 
+test("REQ-SUPPLY-001 upgraded parser and SemVer runtime fail closed on adversarial extension metadata", async () => {
+  const validator = await createExtensionValidator(root);
+  const scanner = new ExtensionPackageScanner({ validator, key: Buffer.alloc(32, 8) });
+  const malformedPackage = await mkdtemp(join(tmpdir(), "kdlc-extension-parser-"));
+  await cp(packageRoot("compatible"), malformedPackage, { recursive: true });
+  await writeFile(join(malformedPackage, "tools/normalizer.mjs"), "export const broken = ;\n");
+  await expectCodeAsync("KDLC_EXTENSION_SOURCE_INVALID", () => scanner.scan(malformedPackage));
+
+  const manifest = JSON.parse(await readFile(join(packageRoot("compatible"), ".kdlc-plugin/plugin.json"), "utf8"));
+  const malformedRange = structuredClone(manifest);
+  malformedRange.compatibility.framework = "1.x.2";
+  expectCode("KDLC_EXTENSION_RANGE_INVALID", () => validatePluginManifest(malformedRange, validator));
+
+  const nonCanonicalVersion = structuredClone(manifest);
+  nonCanonicalVersion.metadata.version = "01.4.0";
+  expectCode("KDLC_EXTENSION_VERSION_INVALID", () => validatePluginManifest(nonCanonicalVersion, validator));
+});
+
 test("FEAT-007 scanner detects post-open swaps without leaking descriptors", async () => {
   const validator = await createExtensionValidator(root); const packageCopy = await mkdtemp(join(tmpdir(), "kdlc-extension-race-"));
   await cp(packageRoot("compatible"), packageCopy, { recursive: true });


### PR DESCRIPTION
Closes #36 for this governed maintenance tranche; issue #36 will be immediately reopened for the protected candidate-harness bootstrap follow-up.

Progresses #36. The protected candidate-test harness checkout pin remains for a separate audited bootstrap follow-up after this tranche is independently reviewed and merged; this PR does not close the issue.

## Traceability

- Requirement IDs: REQ-SUPPLY-001
- Specification §§32, 35, 36

## Five-gate evidence

1. Feature definition: issue #36 records requirements, acceptance criteria, risks, dependencies, and specification references.
2. Plan review: the controlled replacement keeps action upgrades atomic, preserves commit pinning, and verifies runtime dependencies from an integrity-checked install.
3. Development: CodeQL init/analyze are jointly pinned to v4.37.7; dependency-review is pinned to v5.0.0; every non-protected checkout use is pinned to v7.0.1; acorn/semver are exact-pinned to 8.18.0/7.8.5. The protected candidate-test harness remains byte-identical to trusted `main` for a separate audited bootstrap follow-up.
4. Testing: focused fail-closed extension parser and SemVer regressions plus the full Node 24 governance/release/supply-chain suite pass locally.
5. Final review: draft only; independent review and required live checks remain required before merge.

## Generated evidence

- Clean `npm ci --ignore-scripts` installed exact reviewed bytes.
- Notices and SPDX SBOM regenerated: 17 installed dependencies and 18 graph relationships.
- Exact package inventory revalidated: 164 paths (`sha256:c5f6f75b5c6817e3483738e99fffd196017c6a6930ae5d423af29d35024cf185`).
- Package dry run: 164 files, 173024 bytes packed, 725321 bytes unpacked.
- Conformance statement re-bound to the updated traceability bytes; release status remains `not-ready`.

## Verification

Commands and results:
```text
npm test — 183 passed, 0 failed
npm run test:extensions — 8 passed, 0 failed
npm run test:release-evaluation — 9/9 cases
npm run check:supply-chain — 17 dependencies, 18 relationships, 164 paths
npm audit --audit-level=high — 0 vulnerabilities
actionlint — passed
gitleaks --all — no leaks
git diff --check — passed
```

- Node v24.5.0 / npm 11.5.1
- `npm test` — 183/183 passed
- `npm run test:extensions` — 8/8 passed
- `npm run check:governance`
- `npm run test:release-evaluation` — 9/9 offline cases passed
- `npm run check:release-evidence`
- `npm run check:distribution`
- `npm run check:supply-chain`
- `npm audit --audit-level=high` — 0 vulnerabilities
- `npm pack --dry-run --json --ignore-scripts`
- actionlint v1.7.7
- gitleaks full-history scan — no leaks
- `git diff --check`

## Risk and rollback

Risk is concentrated in hosted-runner compatibility for the new Node 24 action majors and in parser/SemVer behavioral changes. Commit-pinned actions, focused adversarial tests, and live draft-PR checks constrain that risk. Rollback is a revert of this single atomic commit, restoring the prior action and package pins together with their matching generated evidence.

Dependabot PRs #31–#34 are intentionally left open until this controlled replacement is independently approved and merged.

## Live draft-PR checks

- Candidate tests: passed using the protected trusted-base harness.
- CodeQL JavaScript/TypeScript: passed (init/analyze v4.37.7).
- Dependency review: passed (v5.0.0).
- Secret history scan: passed (checkout v7.0.1).
- Supply-chain verification: passed (checkout v7.0.1).
- Repository policy reporter: passed after the protected harness was restored byte-identical to trusted `main`. The initial draft correctly rejected that harness change; no verifier weakening is included.


