### PR TITLE
chore: bootstrap protected candidate checkout runtime

### DIFF
--- a/.github/workflows/candidate-tests.yml
+++ b/.github/workflows/candidate-tests.yml
@@ -12,7 +12,7 @@ jobs:
     name: Candidate tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -16,5 +16,5 @@
   "pending_requirements": [
     {"id": "REL-001", "issue": 10, "reason": "Statistical evaluation, final artifact/version agreement, external protections, and independent release verification remain pending.", "release_blocking": true}
   ],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:d4479fe02f7d1d38c18133b1519b28c282b922b36f668ef7dfdf7049f6fddae5"},{"path":"docs/traceability.json","sha256":"sha256:47792ca8660da8d387b8c62bce57533109451634021e0ff80e02ff6b559247ff"},{"path":"docs/release-readiness.md","sha256":"sha256:a4eaa15544f02b72e4a50dbc50bb8b6a5ad91c6e07ac8dce19985f936f5c4652"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:d4479fe02f7d1d38c18133b1519b28c282b922b36f668ef7dfdf7049f6fddae5"},{"path":"docs/traceability.json","sha256":"sha256:a0f435404c421ad491d82ef64f2c6412dcbdf563ac8e3c0d326997ff646cdf00"},{"path":"docs/release-readiness.md","sha256":"sha256:a4eaa15544f02b72e4a50dbc50bb8b6a5ad91c6e07ac8dce19985f936f5c4652"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -210,9 +210,10 @@
       "title": "Refresh dependency and GitHub Action runtimes before release",
       "issue": 36,
       "specification_sections": ["32", "35", "36"],
-      "status": "in-progress",
+      "status": "implemented",
       "evidence": {
         "implementation": [
+          ".github/workflows/candidate-tests.yml",
           ".github/workflows/codeql.yml",
           ".github/workflows/dependency-review.yml",
           ".github/workflows/governance.yml",


### PR DESCRIPTION
Closes #36

## Traceability

- Requirement IDs: REQ-SUPPLY-001
- Specification §§32, 35, 36
- Exact base: `98d994ef70bef6db5fd3f5c7b2711d89945e68ef`

This is the audited protected-harness bootstrap follow-up to #37. It changes the candidate workflow only by replacing its commit-pinned checkout v4 reference with the same independently reviewed checkout v7.0.1 commit already exercised in the repository's other workflows:

`actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`

The test commands, permissions, triggers, Node toolchain, checkout inputs, governance verifier, and protected-harness semantics are unchanged. Traceability is marked implemented and the release conformance evidence hash is rebound to those traceability bytes.

## Five gates

1. Feature definition: issue #36 contains requirements, acceptance criteria, risks, dependencies, and specification references.
2. Plan review: #37 split this protected byte change from ordinary action/runtime upgrades so the trust-boundary exception is explicit.
3. Development: one checkout pin/comment changed; no local enforcement behavior changed.
4. Testing: the exact candidate workflow command and the full release/governance gates pass locally on Node 24.
5. Final review: draft only; an independent read-only review is required before any audited bypass or merge.

## Verification

Commands and results:
```text
npm test — 183 passed, 0 failed
npm run test:release-evaluation — 9/9 cases
npm run check:supply-chain — passed
npm audit --audit-level=high — 0 vulnerabilities
actionlint — passed
Gitleaks full-history — no leaks
git diff --check — passed
```

- Node v24.5.0 / npm 11.5.1
- `npm ci --ignore-scripts`
- `npm test` — 183/183 passed
- `npm run check:release-evidence`
- `npm run test:release-evaluation` — 9/9 offline cases passed
- `npm run check:supply-chain`
- `npm run check:distribution`
- `npm audit --audit-level=high` — 0 vulnerabilities
- actionlint v1.7.7
- Gitleaks full-history scan — no leaks
- `git diff --check`

## Expected bootstrap check disposition

The `Repository policy` status is expected to fail on this PR because the trusted base verifier intentionally requires `.github/workflows/candidate-tests.yml` to remain byte-identical to `main`. The verifier cannot trust its own replacement bytes until this exact protected harness reaches `main`. This is a self-update bootstrap condition, not a test failure; the governance verifier is not modified or weakened.

The candidate workflow itself must pass using checkout v7.0.1, and every other applicable required/live check must pass. Any audited owner bypass remains conditional on an independent read-only final review finding no unresolved critical/high issue, the passing checks and local evidence above, and an explicit recorded bypass reason. I will not self-review, approve, or merge.

## Risk and rollback

Risk is limited to checkout v7 compatibility in the protected candidate workflow. Its exact commit already passed in the non-protected workflows merged through #37, and this PR exercises it in the candidate workflow itself. Rollback is a one-commit revert restoring the prior checkout pin and matching traceability evidence.

