### PR TITLE
fix: bind owner-controlled admin settings attestation

### DIFF
--- a/.github/workflows/release-matrix.yml
+++ b/.github/workflows/release-matrix.yml
@@ -67,6 +67,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           KDLC_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          KDLC_ADMIN_SETTINGS_ATTESTATION: ${{ vars.KDLC_ADMIN_SETTINGS_ATTESTATION }}
         run: |
           if test "$KDLC_BASE_SHA" = fbdf6119c884484974c0b5075fcc60fc97454d5f; then
             mkdir trusted-release-state

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -16,5 +16,5 @@
   "pending_requirements": [
     {"id": "REL-001", "issue": 10, "reason": "Statistical evaluation, final artifact/version agreement, external protections, and independent release verification remain pending.", "release_blocking": true}
   ],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:a235885e1ae3a2b2162bfdd577e28b97d44e32464842253d9ad2b741b78167ae"},{"path":"docs/traceability.json","sha256":"sha256:59c7f4338e0677e5ac7558201dfb7843c8c328c924104688c3a1f788615fe38b"},{"path":"docs/release-readiness.md","sha256":"sha256:1ca7d2a90f6a4c34a089bf2535bf59f54b3283b39e55de62d85af25834fad52d"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:a235885e1ae3a2b2162bfdd577e28b97d44e32464842253d9ad2b741b78167ae"},{"path":"docs/traceability.json","sha256":"sha256:8cd8a6aa7953eb8bf188d4a03e389643dfe99f974f372c44120ecbce135eb5e7"},{"path":"docs/release-readiness.md","sha256":"sha256:333d51ed630808bf3784a74418508989ef130cf0428187eb08e0a204047d937b"}]
 }

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -16,5 +16,5 @@
   "pending_requirements": [
     {"id": "REL-001", "issue": 10, "reason": "Statistical evaluation, final artifact/version agreement, external protections, and independent release verification remain pending.", "release_blocking": true}
   ],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:a235885e1ae3a2b2162bfdd577e28b97d44e32464842253d9ad2b741b78167ae"},{"path":"docs/traceability.json","sha256":"sha256:8cd8a6aa7953eb8bf188d4a03e389643dfe99f974f372c44120ecbce135eb5e7"},{"path":"docs/release-readiness.md","sha256":"sha256:333d51ed630808bf3784a74418508989ef130cf0428187eb08e0a204047d937b"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:a235885e1ae3a2b2162bfdd577e28b97d44e32464842253d9ad2b741b78167ae"},{"path":"docs/traceability.json","sha256":"sha256:8cd8a6aa7953eb8bf188d4a03e389643dfe99f974f372c44120ecbce135eb5e7"},{"path":"docs/release-readiness.md","sha256":"sha256:f1d1b60a02e4862a8a2e3917be605e1bf9b501bd16bee3e46516efec3eba93b8"}]
 }

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -16,5 +16,5 @@
   "pending_requirements": [
     {"id": "REL-001", "issue": 10, "reason": "Statistical evaluation, final artifact/version agreement, external protections, and independent release verification remain pending.", "release_blocking": true}
   ],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:a235885e1ae3a2b2162bfdd577e28b97d44e32464842253d9ad2b741b78167ae"},{"path":"docs/traceability.json","sha256":"sha256:8cd8a6aa7953eb8bf188d4a03e389643dfe99f974f372c44120ecbce135eb5e7"},{"path":"docs/release-readiness.md","sha256":"sha256:f1d1b60a02e4862a8a2e3917be605e1bf9b501bd16bee3e46516efec3eba93b8"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:a235885e1ae3a2b2162bfdd577e28b97d44e32464842253d9ad2b741b78167ae"},{"path":"docs/traceability.json","sha256":"sha256:8cd8a6aa7953eb8bf188d4a03e389643dfe99f974f372c44120ecbce135eb5e7"},{"path":"docs/release-readiness.md","sha256":"sha256:ce9e2a569c1f53b076093ead49024f2f842640af84add3b2e74ecbb14229300c"}]
 }

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -114,7 +114,8 @@ API; it accepts no cached input and cannot run in Actions. It produces only a
 pending record and never asserts a manual confirmation. The separate confirm
 command re-authenticates the same owner, verifies the pending byte and canonical
 hashes, and records a later confirmation time. The attestation binds the
-repository, exact settings, API endpoint, response hash, capture and manual-check
+repository, exact settings, `https://api.github.com` origin, API endpoint,
+response hash, capture and manual-check
 times, actor, capture method, and canonical hash. Missing or stale evidence does
 not make an ordinary private prerelease PR inoperable, but a release candidate
 fails closed unless the record is authentic, policy-preserving, manually

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -92,6 +92,29 @@ read-token job executes only the trusted-base live-state collector and never
 checks out or executes candidate code. Passing workflow evidence is still
 required before release.
 
+The read-only Actions token cannot read the administration-only default
+workflow-permission endpoint. A repository owner must therefore capture that
+endpoint outside Actions, manually cross-check the same values in repository
+settings, and publish the resulting compact JSON as the owner-controlled
+repository variable `KDLC_ADMIN_SETTINGS_ATTESTATION`:
+
+```sh
+gh api repos/aithinkers/knowledge-dlc/actions/permissions/workflow > admin-api.json
+node scripts/create-admin-settings-attestation.mjs \
+  --repository aithinkers/knowledge-dlc --actor owner:release \
+  --input admin-api.json --output admin-attestation.json
+gh variable set KDLC_ADMIN_SETTINGS_ATTESTATION --body "$(tr -d '\n' < admin-attestation.json)"
+```
+
+The local files contain live administrative evidence and must not be committed.
+The attestation binds the repository, exact settings, capture and manual-check
+times, actor, capture method, and canonical hash. Missing or stale evidence does
+not make an ordinary private prerelease PR inoperable, but a release candidate
+fails closed unless the record is authentic, policy-preserving, manually
+cross-checked, and no more than 24 hours old. Public visibility, rulesets,
+issues, checks, and review facts continue to come directly from GitHub's API in
+the trusted-base token job.
+
 ## Live repository settings (verified 2026-08-15)
 
 - Private vulnerability reporting, secret scanning, push protection, and

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -99,15 +99,22 @@ settings, and publish the resulting compact JSON as the owner-controlled
 repository variable `KDLC_ADMIN_SETTINGS_ATTESTATION`:
 
 ```sh
-gh api repos/aithinkers/knowledge-dlc/actions/permissions/workflow > admin-api.json
 node scripts/create-admin-settings-attestation.mjs \
-  --repository aithinkers/knowledge-dlc --actor owner:release \
-  --input admin-api.json --output admin-attestation.json
+  capture --repository aithinkers/knowledge-dlc --output admin-settings-pending.json
+# Now manually compare the pending record's settings with the live Actions UI.
+node scripts/create-admin-settings-attestation.mjs \
+  confirm --repository aithinkers/knowledge-dlc --output admin-attestation.json \
+  --manual-confirmed admin-settings-pending.json
 gh variable set KDLC_ADMIN_SETTINGS_ATTESTATION --body "$(tr -d '\n' < admin-attestation.json)"
 ```
 
 The local files contain live administrative evidence and must not be committed.
-The attestation binds the repository, exact settings, capture and manual-check
+The capture command obtains fresh bytes directly from the authenticated GitHub
+API; it accepts no cached input and cannot run in Actions. It produces only a
+pending record and never asserts a manual confirmation. The separate confirm
+command re-authenticates the same owner, verifies the pending byte and canonical
+hashes, and records a later confirmation time. The attestation binds the
+repository, exact settings, API endpoint, response hash, capture and manual-check
 times, actor, capture method, and canonical hash. Missing or stale evidence does
 not make an ordinary private prerelease PR inoperable, but a release candidate
 fails closed unless the record is authentic, policy-preserving, manually

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -230,6 +230,26 @@
       }
     },
     {
+      "id": "REQ-RELEASE-001",
+      "title": "Bind administration-only release settings through owner attestation",
+      "issue": 44,
+      "specification_sections": ["35", "36"],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          ".github/workflows/release-matrix.yml",
+          "scripts/collect-release-state.mjs",
+          "scripts/create-admin-settings-attestation.mjs",
+          "scripts/release-state-derivation.mjs",
+          "scripts/release-evidence-validation.mjs"
+        ],
+        "tests": [
+          "tests/governance/release-matrix.test.mjs",
+          "tests/governance/release-candidate-evidence.test.mjs"
+        ]
+      }
+    },
+    {
       "id": "REQ-SUPPLY-001",
       "title": "Refresh dependency and GitHub Action runtimes before release",
       "issue": 36,

--- a/scripts/collect-release-state.mjs
+++ b/scripts/collect-release-state.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
-import { deriveRulesetState } from "./release-state-derivation.mjs";
+import { deriveRulesetState, evaluateAdminSettingsAttestation } from "./release-state-derivation.mjs";
 
 const [output] = process.argv.slice(2); if (!output || process.argv.length !== 3) throw new Error("usage: node scripts/collect-release-state.mjs <output-directory>");
 const [owner, repository] = (process.env.GITHUB_REPOSITORY ?? "").split("/"); const token = process.env.GH_TOKEN; const event = JSON.parse(await readFile(process.env.GITHUB_EVENT_PATH, "utf8"));
@@ -9,14 +9,16 @@ if (!owner || !repository || !token || !event.pull_request) throw new Error("tru
 const headers = { authorization: `Bearer ${token}`, accept: "application/vnd.github+json", "x-github-api-version": "2022-11-28" };
 const api = async (path) => { const response = await fetch(`https://api.github.com/repos/${owner}/${repository}${path}`, { headers }); if (!response.ok) throw new Error(`${path}: ${response.status}`); return response.json(); };
 const apiAll = async (path) => { const values = []; for (let page = 1; ; page += 1) { const batch = await api(`${path}${path.includes("?") ? "&" : "?"}per_page=100&page=${page}`); values.push(...batch); if (batch.length < 100) return values; } };
-const [repo, workflowPermissions] = await Promise.all([api(""), api("/actions/permissions/workflow")]);
+const repo = await api("");
 const dependencies = await Promise.all(Array.from({ length: 8 }, (_, index) => api(`/issues/${index + 2}`)));
 const summaries = await api("/rulesets?includes_parents=true&per_page=100");
 const rulesets = await Promise.all(summaries.filter(({ target, enforcement }) => target === "branch" && enforcement === "active").map(({ id }) => api(`/rulesets/${id}`)));
 const derivedRuleset = deriveRulesetState(rulesets, { baseRef: event.pull_request.base.ref, defaultBranch: repo.default_branch });
+const admin = evaluateAdminSettingsAttestation(process.env.KDLC_ADMIN_SETTINGS_ATTESTATION, { repository: `${owner}/${repository}` });
 const settings = {
   visibility: repo.visibility ?? "unknown",
-  actions: { default_workflow_permissions: workflowPermissions.default_workflow_permissions ?? "unknown", can_approve_pull_request_reviews: workflowPermissions.can_approve_pull_request_reviews === true },
+  actions: admin.attestation?.settings ?? { default_workflow_permissions: "unknown", can_approve_pull_request_reviews: null },
+  admin_attestation: { status: admin.status, record: admin.attestation },
   release_blocking_issues_closed: dependencies.every(({ state, pull_request }) => state === "closed" && !pull_request),
   ruleset: derivedRuleset
 };

--- a/scripts/create-admin-settings-attestation.mjs
+++ b/scripts/create-admin-settings-attestation.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { open, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { issueAdminSettingsAttestation } from "./release-state-derivation.mjs";
+
+const [repositoryFlag, repository, actorFlag, actor, inputFlag, input, outputFlag, output] = process.argv.slice(2);
+if (repositoryFlag !== "--repository" || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(repository ?? "") || actorFlag !== "--actor" || !actor
+  || inputFlag !== "--input" || !input || outputFlag !== "--output" || !output) throw new Error("usage: node scripts/create-admin-settings-attestation.mjs --repository <owner/repo> --actor <owner-identity> --input <admin-api.json> --output <attestation.json>");
+const source = JSON.parse(await readFile(resolve(input), "utf8"));
+if (JSON.stringify(Object.keys(source).sort()) !== JSON.stringify(["can_approve_pull_request_reviews", "default_workflow_permissions"].sort())
+  || !["read", "write"].includes(source.default_workflow_permissions) || typeof source.can_approve_pull_request_reviews !== "boolean") throw new Error("admin API input has an unexpected shape");
+const capturedAt = new Date().toISOString();
+const record = issueAdminSettingsAttestation({ repository, capturedAt, confirmedAt: capturedAt, actor, settings: source });
+const handle = await open(resolve(output), "wx", 0o600); try { await handle.writeFile(`${JSON.stringify(record)}\n`); } finally { await handle.close(); }
+console.log("Created owner admin-settings attestation from supplied live API bytes; manually cross-check the settings UI before publishing the repository variable.");

--- a/scripts/create-admin-settings-attestation.mjs
+++ b/scripts/create-admin-settings-attestation.mjs
@@ -1,16 +1,34 @@
 #!/usr/bin/env node
+import { execFile } from "node:child_process";
 import { open, readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { promisify } from "node:util";
 
-import { issueAdminSettingsAttestation } from "./release-state-derivation.mjs";
+import { createAdminSettingsCapture, issueAdminSettingsAttestation } from "./release-state-derivation.mjs";
 
-const [repositoryFlag, repository, actorFlag, actor, inputFlag, input, outputFlag, output] = process.argv.slice(2);
-if (repositoryFlag !== "--repository" || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(repository ?? "") || actorFlag !== "--actor" || !actor
-  || inputFlag !== "--input" || !input || outputFlag !== "--output" || !output) throw new Error("usage: node scripts/create-admin-settings-attestation.mjs --repository <owner/repo> --actor <owner-identity> --input <admin-api.json> --output <attestation.json>");
-const source = JSON.parse(await readFile(resolve(input), "utf8"));
-if (JSON.stringify(Object.keys(source).sort()) !== JSON.stringify(["can_approve_pull_request_reviews", "default_workflow_permissions"].sort())
-  || !["read", "write"].includes(source.default_workflow_permissions) || typeof source.can_approve_pull_request_reviews !== "boolean") throw new Error("admin API input has an unexpected shape");
-const capturedAt = new Date().toISOString();
-const record = issueAdminSettingsAttestation({ repository, capturedAt, confirmedAt: capturedAt, actor, settings: source });
-const handle = await open(resolve(output), "wx", 0o600); try { await handle.writeFile(`${JSON.stringify(record)}\n`); } finally { await handle.close(); }
-console.log("Created owner admin-settings attestation from supplied live API bytes; manually cross-check the settings UI before publishing the repository variable.");
+const execute = promisify(execFile);
+const repositoryPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u;
+const expectedSettings = (value) => value && !Array.isArray(value)
+  && JSON.stringify(Object.keys(value).sort()) === JSON.stringify(["can_approve_pull_request_reviews", "default_workflow_permissions"].sort())
+  && ["read", "write"].includes(value.default_workflow_permissions) && typeof value.can_approve_pull_request_reviews === "boolean";
+const writeExclusive = async (path, value) => { const handle = await open(resolve(path), "wx", 0o600); try { await handle.writeFile(`${JSON.stringify(value)}\n`); } finally { await handle.close(); } };
+const ghActor = async () => (await execute("gh", ["api", "user", "--jq", ".login"], { encoding: "utf8", maxBuffer: 1024 * 1024 })).stdout.trim();
+
+if (process.env.GITHUB_ACTIONS === "true") throw new Error("admin settings capture and confirmation are prohibited in GitHub Actions");
+const [command, repositoryFlag, repository, outputFlag, output, confirmationFlag] = process.argv.slice(2);
+if (!repositoryPattern.test(repository ?? "") || repositoryFlag !== "--repository" || outputFlag !== "--output" || !output) {
+  throw new Error("usage: ... capture --repository <owner/repo> --output <pending.json> | confirm --repository <owner/repo> --output <attestation.json> --manual-confirmed <pending.json>");
+}
+const actor = await ghActor();
+if (command === "capture" && confirmationFlag === undefined) {
+  const { stdout } = await execute("gh", ["api", `repos/${repository}/actions/permissions/workflow`], { encoding: "buffer", maxBuffer: 1024 * 1024 });
+  const bytes = Buffer.from(stdout); const settings = JSON.parse(bytes.toString("utf8"));
+  if (!expectedSettings(settings)) throw new Error("live admin API response has an unexpected shape");
+  await writeExclusive(output, createAdminSettingsCapture({ repository, capturedAt: new Date().toISOString(), actor, responseBytes: bytes }));
+  console.log("Captured live admin API bytes. Manually compare them with the repository Actions settings UI, then run the separate confirm command.");
+} else if (command === "confirm" && confirmationFlag === "--manual-confirmed") {
+  const pendingPath = process.argv.at(-1); const capture = JSON.parse(await readFile(resolve(pendingPath), "utf8"));
+  if (capture.repository !== repository) throw new Error("capture repository does not match confirmation repository");
+  await writeExclusive(output, issueAdminSettingsAttestation({ capture, confirmedAt: new Date().toISOString(), actor }));
+  console.log("Confirmed the owner-observed settings against the bound live capture. Publish only this attestation file as the repository variable.");
+} else throw new Error("capture and confirm are separate operations; confirmation requires --manual-confirmed <pending.json>");

--- a/scripts/create-admin-settings-attestation.mjs
+++ b/scripts/create-admin-settings-attestation.mjs
@@ -12,7 +12,7 @@ const expectedSettings = (value) => value && !Array.isArray(value)
   && JSON.stringify(Object.keys(value).sort()) === JSON.stringify(["can_approve_pull_request_reviews", "default_workflow_permissions"].sort())
   && ["read", "write"].includes(value.default_workflow_permissions) && typeof value.can_approve_pull_request_reviews === "boolean";
 const writeExclusive = async (path, value) => { const handle = await open(resolve(path), "wx", 0o600); try { await handle.writeFile(`${JSON.stringify(value)}\n`); } finally { await handle.close(); } };
-const ghActor = async () => (await execute("gh", ["api", "user", "--jq", ".login"], { encoding: "utf8", maxBuffer: 1024 * 1024 })).stdout.trim();
+const ghActor = async () => (await execute("gh", ["api", "--hostname", "github.com", "user", "--jq", ".login"], { encoding: "utf8", maxBuffer: 1024 * 1024 })).stdout.trim();
 
 if (process.env.GITHUB_ACTIONS === "true") throw new Error("admin settings capture and confirmation are prohibited in GitHub Actions");
 const [command, repositoryFlag, repository, outputFlag, output, confirmationFlag] = process.argv.slice(2);
@@ -21,7 +21,7 @@ if (!repositoryPattern.test(repository ?? "") || repositoryFlag !== "--repositor
 }
 const actor = await ghActor();
 if (command === "capture" && confirmationFlag === undefined) {
-  const { stdout } = await execute("gh", ["api", `repos/${repository}/actions/permissions/workflow`], { encoding: "buffer", maxBuffer: 1024 * 1024 });
+  const { stdout } = await execute("gh", ["api", "--hostname", "github.com", `repos/${repository}/actions/permissions/workflow`], { encoding: "buffer", maxBuffer: 1024 * 1024 });
   const bytes = Buffer.from(stdout); const settings = JSON.parse(bytes.toString("utf8"));
   if (!expectedSettings(settings)) throw new Error("live admin API response has an unexpected shape");
   await writeExclusive(output, createAdminSettingsCapture({ repository, capturedAt: new Date().toISOString(), actor, responseBytes: bytes }));

--- a/scripts/release-evidence-validation.mjs
+++ b/scripts/release-evidence-validation.mjs
@@ -8,6 +8,7 @@ import addFormats from "ajv-formats";
 import { descriptors } from "../packages/normalizers/index.mjs";
 import { artifactHash } from "../packages/core/index.mjs";
 import { readTrustedFile } from "./supply-chain-validation.mjs";
+import { evaluateAdminSettingsAttestation } from "./release-state-derivation.mjs";
 import { conformanceModules, mandatoryProfileRequirements, mandatoryReleaseCases } from "./release-evidence-definition.mjs";
 import { validateStatisticalEvidence } from "./statistical-evidence-validation.mjs";
 
@@ -27,7 +28,7 @@ const schemas = Object.freeze({
   report: "core/schemas/release/evaluation-report.schema.json",
 });
 
-export async function validateReleaseCandidateEvidence(root, { version, headSha, matrixResults, trustedRepositorySnapshot, trustedReviewRecord, precheck = false } = {}) {
+export async function validateReleaseCandidateEvidence(root, { version, headSha, matrixResults, trustedRepositorySnapshot, trustedReviewRecord, repository = process.env.GITHUB_REPOSITORY, now = new Date().toISOString(), precheck = false } = {}) {
   const failures = []; let evidence; let schema;
   try { schema = await json(root, "core/schemas/release/release-candidate-evidence.schema.json"); evidence = await json(root, "distribution/release/release-candidate-evidence.json"); }
   catch (error) { return [`release-candidate evidence is unavailable: ${error.message}`]; }
@@ -55,7 +56,9 @@ export async function validateReleaseCandidateEvidence(root, { version, headSha,
   const expectedChecks = ["Candidate tests", "CodeQL (JavaScript/TypeScript)", "Dependency review", "Pull request traceability", "Release matrix", "Repository policy", "Secret history scan", "Supply-chain verification"].sort();
   try {
     const settings = JSON.parse(await readFile(trustedRepositorySnapshot, "utf8")); const ruleset = settings.ruleset;
-    if (settings.visibility !== "public" || settings.actions?.default_workflow_permissions !== "read" || settings.actions.can_approve_pull_request_reviews !== false || settings.release_blocking_issues_closed !== true || ruleset?.active !== true || ruleset.default_branch !== true || ruleset.prevents_deletion !== true || ruleset.prevents_non_fast_forward !== true || ruleset.linear_history !== true || ruleset.strict_status_checks !== true || ruleset.direct_push_bypass !== false || ruleset.pull_request?.required_approvals < 1 || ruleset.pull_request.require_code_owner_review !== true || ruleset.pull_request.dismiss_stale_reviews !== true || ruleset.pull_request.require_last_push_approval !== true || ruleset.pull_request.require_thread_resolution !== true || !same(ruleset.pull_request.allowed_merge_methods, ["squash"]) || !same(ruleset.required_checks, expectedChecks)) failures.push("trusted live repository ruleset is not release-ready");
+    const admin = evaluateAdminSettingsAttestation(JSON.stringify(settings.admin_attestation?.record), { repository, now });
+    if (settings.admin_attestation?.status !== "current" || admin.status !== "current" || !same(settings.actions, admin.attestation?.settings)
+      || settings.visibility !== "public" || settings.release_blocking_issues_closed !== true || ruleset?.active !== true || ruleset.default_branch !== true || ruleset.prevents_deletion !== true || ruleset.prevents_non_fast_forward !== true || ruleset.linear_history !== true || ruleset.strict_status_checks !== true || ruleset.direct_push_bypass !== false || ruleset.pull_request?.required_approvals < 1 || ruleset.pull_request.require_code_owner_review !== true || ruleset.pull_request.dismiss_stale_reviews !== true || ruleset.pull_request.require_last_push_approval !== true || ruleset.pull_request.require_thread_resolution !== true || !same(ruleset.pull_request.allowed_merge_methods, ["squash"]) || !same(ruleset.required_checks, expectedChecks)) failures.push("trusted live repository ruleset or admin attestation is not release-ready");
   } catch { failures.push("trusted live repository ruleset is unavailable or invalid"); }
   try {
     const review = JSON.parse(await readFile(trustedReviewRecord, "utf8"));

--- a/scripts/release-state-derivation.mjs
+++ b/scripts/release-state-derivation.mjs
@@ -43,14 +43,36 @@ export function deriveRulesetState(rulesets, { baseRef, defaultBranch }) {
   };
 }
 const ADMIN_ATTESTATION_VERSION = "kdlc.dev/admin-settings-attestation/v1alpha1";
+const ADMIN_CAPTURE_VERSION = "kdlc.dev/admin-settings-capture/v1alpha1";
 const ADMIN_CAPTURE_METHOD = "owner-live-admin-api-and-manual-ui";
+const ADMIN_API_METHOD = "authenticated-gh-admin-api";
 const ADMIN_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const ADMIN_MAX_CONFIRM_DELAY_MS = 60 * 60 * 1000;
 const exactKeys = (value, keys) => value && typeof value === "object" && !Array.isArray(value) && JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...keys].sort());
 const digest = (value) => `sha256:${createHash("sha256").update(canonicalize(value)).digest("hex")}`;
 
-export function issueAdminSettingsAttestation({ repository, capturedAt, confirmedAt, actor, settings }) {
-  const payload = { api_version: ADMIN_ATTESTATION_VERSION, repository, captured_at: capturedAt,
-    settings: structuredClone(settings), manual_cross_check: { confirmed: true, confirmed_at: confirmedAt, method: ADMIN_CAPTURE_METHOD, actor } };
+export function createAdminSettingsCapture({ repository, capturedAt, actor, responseBytes }) {
+  const endpoint = `/repos/${repository}/actions/permissions/workflow`;
+  const bytes = Buffer.isBuffer(responseBytes) ? responseBytes : Buffer.from(responseBytes);
+  const settings = JSON.parse(bytes.toString("utf8"));
+  const payload = { api_version: ADMIN_CAPTURE_VERSION, repository, captured_at: capturedAt, actor,
+    capture: { method: ADMIN_API_METHOD, endpoint, response_sha256: `sha256:${createHash("sha256").update(bytes).digest("hex")}` },
+    response_base64: bytes.toString("base64"), settings: structuredClone(settings) };
+  return Object.freeze({ ...payload, canonical_sha256: digest(payload) });
+}
+
+export function issueAdminSettingsAttestation({ capture, confirmedAt, actor }) {
+  const bytes = Buffer.from(capture.response_base64 ?? "", "base64");
+  const capturePayload = { api_version: capture.api_version, repository: capture.repository, captured_at: capture.captured_at,
+    actor: capture.actor, capture: capture.capture, response_base64: capture.response_base64, settings: capture.settings };
+  if (!exactKeys(capture, [...Object.keys(capturePayload), "canonical_sha256"]) || capture.api_version !== ADMIN_CAPTURE_VERSION
+    || capture.canonical_sha256 !== digest(capturePayload) || capture.capture?.method !== ADMIN_API_METHOD
+    || capture.capture?.endpoint !== `/repos/${capture.repository}/actions/permissions/workflow`
+    || capture.capture?.response_sha256 !== `sha256:${createHash("sha256").update(bytes).digest("hex")}`
+    || JSON.stringify(JSON.parse(bytes.toString("utf8"))) !== JSON.stringify(capture.settings) || actor !== capture.actor) throw new Error("invalid or unauthorized admin settings capture");
+  const payload = { api_version: ADMIN_ATTESTATION_VERSION, repository: capture.repository, captured_at: capture.captured_at,
+    capture: { ...structuredClone(capture.capture), actor: capture.actor, record_sha256: capture.canonical_sha256 }, settings: structuredClone(capture.settings),
+    manual_cross_check: { confirmed: true, confirmed_at: confirmedAt, method: ADMIN_CAPTURE_METHOD, actor } };
   return Object.freeze({ ...payload, canonical_sha256: digest(payload) });
 }
 
@@ -58,16 +80,21 @@ export function evaluateAdminSettingsAttestation(serialized, { repository, now =
   if (typeof serialized !== "string" || serialized.trim() === "") return { status: "unavailable", attestation: null };
   let value; try { value = JSON.parse(serialized); } catch { return { status: "invalid", attestation: null }; }
   const manual = value?.manual_cross_check; const settings = value?.settings;
-  const validShape = exactKeys(value, ["api_version", "repository", "captured_at", "settings", "manual_cross_check", "canonical_sha256"])
+  const validShape = exactKeys(value, ["api_version", "repository", "captured_at", "capture", "settings", "manual_cross_check", "canonical_sha256"])
     && exactKeys(settings, ["default_workflow_permissions", "can_approve_pull_request_reviews"])
-    && exactKeys(manual, ["confirmed", "confirmed_at", "method", "actor"]);
+    && exactKeys(manual, ["confirmed", "confirmed_at", "method", "actor"])
+    && exactKeys(value?.capture, ["method", "endpoint", "response_sha256", "record_sha256", "actor"]);
   const payload = validShape ? { api_version: value.api_version, repository: value.repository, captured_at: value.captured_at,
-    settings: value.settings, manual_cross_check: value.manual_cross_check } : null;
+    capture: value.capture, settings: value.settings, manual_cross_check: value.manual_cross_check } : null;
   const captured = Date.parse(value?.captured_at), confirmed = Date.parse(manual?.confirmed_at), current = Date.parse(now);
   const authentic = validShape && value.api_version === ADMIN_ATTESTATION_VERSION && value.repository === repository
     && isRfc3339Instant(value.captured_at) && isRfc3339Instant(manual.confirmed_at) && isRfc3339Instant(now)
     && manual.confirmed === true && manual.method === ADMIN_CAPTURE_METHOD && typeof manual.actor === "string" && manual.actor.length > 0
-    && Number.isFinite(captured) && Number.isFinite(confirmed) && confirmed >= captured && confirmed - captured <= 60 * 60 * 1000
+    && value.capture.method === ADMIN_API_METHOD && value.capture.endpoint === `/repos/${repository}/actions/permissions/workflow`
+    && /^sha256:[0-9a-f]{64}$/u.test(value.capture.response_sha256) && /^sha256:[0-9a-f]{64}$/u.test(value.capture.record_sha256)
+    && value.capture.actor === manual.actor
+    && Number.isFinite(captured) && Number.isFinite(confirmed) && Number.isFinite(current)
+    && confirmed > captured && confirmed <= current && confirmed - captured <= ADMIN_MAX_CONFIRM_DELAY_MS
     && value.canonical_sha256 === digest(payload);
   if (!authentic) return { status: "invalid", attestation: null };
   if (captured > current || current - captured > maxAgeMs) return { status: "stale", attestation: structuredClone(value) };

--- a/scripts/release-state-derivation.mjs
+++ b/scripts/release-state-derivation.mjs
@@ -1,3 +1,9 @@
+import { createHash } from "node:crypto";
+
+import canonicalize from "canonicalize";
+
+import { isRfc3339Instant } from "../packages/core/src/temporal.mjs";
+
 function globPattern(pattern) {
   if (/[\[\]]/u.test(pattern)) throw new Error("unsupported ruleset character-set pattern");
   let source = "";
@@ -35,4 +41,36 @@ export function deriveRulesetState(rulesets, { baseRef, defaultBranch }) {
     strict_status_checks: statuses.some(({ strict_required_status_checks_policy }) => strict_required_status_checks_policy === true), required_checks: [...new Set(statuses.flatMap(({ required_status_checks }) => (required_status_checks ?? []).map(({ context }) => context)))].sort(),
     direct_push_bypass: applicable.some(({ bypass_actors }) => (bypass_actors ?? []).some(({ bypass_mode }) => bypass_mode === "always"))
   };
+}
+const ADMIN_ATTESTATION_VERSION = "kdlc.dev/admin-settings-attestation/v1alpha1";
+const ADMIN_CAPTURE_METHOD = "owner-live-admin-api-and-manual-ui";
+const ADMIN_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const exactKeys = (value, keys) => value && typeof value === "object" && !Array.isArray(value) && JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...keys].sort());
+const digest = (value) => `sha256:${createHash("sha256").update(canonicalize(value)).digest("hex")}`;
+
+export function issueAdminSettingsAttestation({ repository, capturedAt, confirmedAt, actor, settings }) {
+  const payload = { api_version: ADMIN_ATTESTATION_VERSION, repository, captured_at: capturedAt,
+    settings: structuredClone(settings), manual_cross_check: { confirmed: true, confirmed_at: confirmedAt, method: ADMIN_CAPTURE_METHOD, actor } };
+  return Object.freeze({ ...payload, canonical_sha256: digest(payload) });
+}
+
+export function evaluateAdminSettingsAttestation(serialized, { repository, now = new Date().toISOString(), maxAgeMs = ADMIN_MAX_AGE_MS } = {}) {
+  if (typeof serialized !== "string" || serialized.trim() === "") return { status: "unavailable", attestation: null };
+  let value; try { value = JSON.parse(serialized); } catch { return { status: "invalid", attestation: null }; }
+  const manual = value?.manual_cross_check; const settings = value?.settings;
+  const validShape = exactKeys(value, ["api_version", "repository", "captured_at", "settings", "manual_cross_check", "canonical_sha256"])
+    && exactKeys(settings, ["default_workflow_permissions", "can_approve_pull_request_reviews"])
+    && exactKeys(manual, ["confirmed", "confirmed_at", "method", "actor"]);
+  const payload = validShape ? { api_version: value.api_version, repository: value.repository, captured_at: value.captured_at,
+    settings: value.settings, manual_cross_check: value.manual_cross_check } : null;
+  const captured = Date.parse(value?.captured_at), confirmed = Date.parse(manual?.confirmed_at), current = Date.parse(now);
+  const authentic = validShape && value.api_version === ADMIN_ATTESTATION_VERSION && value.repository === repository
+    && isRfc3339Instant(value.captured_at) && isRfc3339Instant(manual.confirmed_at) && isRfc3339Instant(now)
+    && manual.confirmed === true && manual.method === ADMIN_CAPTURE_METHOD && typeof manual.actor === "string" && manual.actor.length > 0
+    && Number.isFinite(captured) && Number.isFinite(confirmed) && confirmed >= captured && confirmed - captured <= 60 * 60 * 1000
+    && value.canonical_sha256 === digest(payload);
+  if (!authentic) return { status: "invalid", attestation: null };
+  if (captured > current || current - captured > maxAgeMs) return { status: "stale", attestation: structuredClone(value) };
+  const policyReady = settings.default_workflow_permissions === "read" && settings.can_approve_pull_request_reviews === false;
+  return { status: policyReady ? "current" : "weakened", attestation: structuredClone(value) };
 }

--- a/scripts/release-state-derivation.mjs
+++ b/scripts/release-state-derivation.mjs
@@ -46,6 +46,7 @@ const ADMIN_ATTESTATION_VERSION = "kdlc.dev/admin-settings-attestation/v1alpha1"
 const ADMIN_CAPTURE_VERSION = "kdlc.dev/admin-settings-capture/v1alpha1";
 const ADMIN_CAPTURE_METHOD = "owner-live-admin-api-and-manual-ui";
 const ADMIN_API_METHOD = "authenticated-gh-admin-api";
+const ADMIN_API_ORIGIN = "https://api.github.com";
 const ADMIN_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const ADMIN_MAX_CONFIRM_DELAY_MS = 60 * 60 * 1000;
 const exactKeys = (value, keys) => value && typeof value === "object" && !Array.isArray(value) && JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...keys].sort());
@@ -56,7 +57,7 @@ export function createAdminSettingsCapture({ repository, capturedAt, actor, resp
   const bytes = Buffer.isBuffer(responseBytes) ? responseBytes : Buffer.from(responseBytes);
   const settings = JSON.parse(bytes.toString("utf8"));
   const payload = { api_version: ADMIN_CAPTURE_VERSION, repository, captured_at: capturedAt, actor,
-    capture: { method: ADMIN_API_METHOD, endpoint, response_sha256: `sha256:${createHash("sha256").update(bytes).digest("hex")}` },
+    capture: { method: ADMIN_API_METHOD, api_origin: ADMIN_API_ORIGIN, endpoint, response_sha256: `sha256:${createHash("sha256").update(bytes).digest("hex")}` },
     response_base64: bytes.toString("base64"), settings: structuredClone(settings) };
   return Object.freeze({ ...payload, canonical_sha256: digest(payload) });
 }
@@ -67,6 +68,7 @@ export function issueAdminSettingsAttestation({ capture, confirmedAt, actor }) {
     actor: capture.actor, capture: capture.capture, response_base64: capture.response_base64, settings: capture.settings };
   if (!exactKeys(capture, [...Object.keys(capturePayload), "canonical_sha256"]) || capture.api_version !== ADMIN_CAPTURE_VERSION
     || capture.canonical_sha256 !== digest(capturePayload) || capture.capture?.method !== ADMIN_API_METHOD
+    || capture.capture?.api_origin !== ADMIN_API_ORIGIN
     || capture.capture?.endpoint !== `/repos/${capture.repository}/actions/permissions/workflow`
     || capture.capture?.response_sha256 !== `sha256:${createHash("sha256").update(bytes).digest("hex")}`
     || JSON.stringify(JSON.parse(bytes.toString("utf8"))) !== JSON.stringify(capture.settings) || actor !== capture.actor) throw new Error("invalid or unauthorized admin settings capture");
@@ -83,14 +85,15 @@ export function evaluateAdminSettingsAttestation(serialized, { repository, now =
   const validShape = exactKeys(value, ["api_version", "repository", "captured_at", "capture", "settings", "manual_cross_check", "canonical_sha256"])
     && exactKeys(settings, ["default_workflow_permissions", "can_approve_pull_request_reviews"])
     && exactKeys(manual, ["confirmed", "confirmed_at", "method", "actor"])
-    && exactKeys(value?.capture, ["method", "endpoint", "response_sha256", "record_sha256", "actor"]);
+    && exactKeys(value?.capture, ["method", "api_origin", "endpoint", "response_sha256", "record_sha256", "actor"]);
   const payload = validShape ? { api_version: value.api_version, repository: value.repository, captured_at: value.captured_at,
     capture: value.capture, settings: value.settings, manual_cross_check: value.manual_cross_check } : null;
   const captured = Date.parse(value?.captured_at), confirmed = Date.parse(manual?.confirmed_at), current = Date.parse(now);
   const authentic = validShape && value.api_version === ADMIN_ATTESTATION_VERSION && value.repository === repository
     && isRfc3339Instant(value.captured_at) && isRfc3339Instant(manual.confirmed_at) && isRfc3339Instant(now)
     && manual.confirmed === true && manual.method === ADMIN_CAPTURE_METHOD && typeof manual.actor === "string" && manual.actor.length > 0
-    && value.capture.method === ADMIN_API_METHOD && value.capture.endpoint === `/repos/${repository}/actions/permissions/workflow`
+    && value.capture.method === ADMIN_API_METHOD && value.capture.api_origin === ADMIN_API_ORIGIN
+    && value.capture.endpoint === `/repos/${repository}/actions/permissions/workflow`
     && /^sha256:[0-9a-f]{64}$/u.test(value.capture.response_sha256) && /^sha256:[0-9a-f]{64}$/u.test(value.capture.record_sha256)
     && value.capture.actor === manual.actor
     && Number.isFinite(captured) && Number.isFinite(confirmed) && Number.isFinite(current)

--- a/tests/governance/release-candidate-evidence.test.mjs
+++ b/tests/governance/release-candidate-evidence.test.mjs
@@ -6,7 +6,7 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 import { validateReleaseCandidateEvidence } from "../../scripts/release-evidence-validation.mjs";
-import { deriveRulesetState } from "../../scripts/release-state-derivation.mjs";
+import { deriveRulesetState, evaluateAdminSettingsAttestation, issueAdminSettingsAttestation } from "../../scripts/release-state-derivation.mjs";
 
 const root = resolve(import.meta.dirname, "../.."); const hash = (bytes) => `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
 const cells = ["ubuntu-node22", "ubuntu-node24", "windows-node22", "windows-node24", "macos-node22", "macos-node24"];
@@ -23,10 +23,12 @@ test("REL-001 release-candidate gate derives package, supply-chain, settings, an
   const evidence = { api_version: "kdlc.dev/release-candidate-evidence/v1alpha1", version, changelog: { path: "CHANGELOG.md", sha256: hash(changelog) } };
   await writeFile(resolve(candidate, "distribution/release/release-candidate-evidence.json"), `${JSON.stringify(evidence, null, 2)}\n`);
   const settingsPath = resolve(candidate, "settings.json"); const reviewPath = resolve(candidate, "review.json");
-  const settings = { visibility: "public", actions: { default_workflow_permissions: "read", can_approve_pull_request_reviews: false }, release_blocking_issues_closed: true, ruleset: { ids: [1], active: true, default_branch: true, prevents_deletion: true, prevents_non_fast_forward: true, linear_history: true, pull_request: { required_approvals: 1, require_code_owner_review: true, dismiss_stale_reviews: true, require_last_push_approval: true, require_thread_resolution: true, allowed_merge_methods: ["squash"] }, strict_status_checks: true, required_checks: ["Candidate tests", "CodeQL (JavaScript/TypeScript)", "Dependency review", "Pull request traceability", "Release matrix", "Repository policy", "Secret history scan", "Supply-chain verification"], direct_push_bypass: false } };
+  const actions = { default_workflow_permissions: "read", can_approve_pull_request_reviews: false };
+  const attestation = issueAdminSettingsAttestation({ repository: "aithinkers/knowledge-dlc", capturedAt: "2026-08-15T00:00:00Z", confirmedAt: "2026-08-15T00:05:00Z", actor: "owner:release", settings: actions });
+  const settings = { visibility: "public", actions, admin_attestation: { status: "current", record: attestation }, release_blocking_issues_closed: true, ruleset: { ids: [1], active: true, default_branch: true, prevents_deletion: true, prevents_non_fast_forward: true, linear_history: true, pull_request: { required_approvals: 1, require_code_owner_review: true, dismiss_stale_reviews: true, require_last_push_approval: true, require_thread_resolution: true, allowed_merge_methods: ["squash"] }, strict_status_checks: true, required_checks: ["Candidate tests", "CodeQL (JavaScript/TypeScript)", "Dependency review", "Pull request traceability", "Release matrix", "Repository policy", "Secret history scan", "Supply-chain verification"], direct_push_bypass: false } };
   const review = { head_sha: head, decision: "approved", evidence_kind: "independent-agent-comment", evidence_id: 42, evidence_url: "https://github.test/review/42", actor: "review-agent", observed_at: "2026-08-15T00:00:00Z" };
   await writeFile(settingsPath, JSON.stringify(settings)); await writeFile(reviewPath, JSON.stringify(review));
-  const trusted = { version, headSha: head, matrixResults: matrix(head), trustedRepositorySnapshot: settingsPath, trustedReviewRecord: reviewPath };
+  const trusted = { version, headSha: head, matrixResults: matrix(head), trustedRepositorySnapshot: settingsPath, trustedReviewRecord: reviewPath, repository: "aithinkers/knowledge-dlc", now: "2026-08-15T12:00:00Z" };
   assert.deepEqual(await validateReleaseCandidateEvidence(candidate, trusted), []);
 
   const osMetadata = matrix(head); for (const result of osMetadata.filter(({ platform }) => platform.os === "win32")) { result.observed_evidence.package.first_sha256 = result.observed_evidence.package.second_sha256 = "9".repeat(64); result.observed_evidence.package.manifest_sha256 = "8".repeat(64); }
@@ -41,11 +43,37 @@ test("REL-001 release-candidate gate derives package, supply-chain, settings, an
   await writeFile(settingsPath, JSON.stringify(settings)); await writeFile(reviewPath, JSON.stringify({ ...review, head_sha: "f".repeat(40) }));
   assert.ok((await validateReleaseCandidateEvidence(candidate, trusted)).some((failure) => failure.includes("exact-head")));
   await writeFile(reviewPath, JSON.stringify(review)); await writeFile(settingsPath, JSON.stringify({ ...settings, actions: { default_workflow_permissions: "write", can_approve_pull_request_reviews: false } }));
-  assert.ok((await validateReleaseCandidateEvidence(candidate, trusted)).some((failure) => failure.includes("ruleset")));
+  assert.ok((await validateReleaseCandidateEvidence(candidate, trusted)).some((failure) => failure.includes("attestation")));
+  for (const mutation of ["stale", "forged", "wrong-repository", "weakened"]) {
+    let record = structuredClone(attestation); let mutationTrusted = trusted;
+    if (mutation === "stale") mutationTrusted = { ...trusted, now: "2026-08-16T00:00:00.001Z" };
+    if (mutation === "forged") record.settings.default_workflow_permissions = "write";
+    if (mutation === "wrong-repository") record = issueAdminSettingsAttestation({ repository: "attacker/fork", capturedAt: "2026-08-15T00:00:00Z", confirmedAt: "2026-08-15T00:05:00Z", actor: "owner:release", settings: actions });
+    if (mutation === "weakened") record = issueAdminSettingsAttestation({ repository: trusted.repository, capturedAt: "2026-08-15T00:00:00Z", confirmedAt: "2026-08-15T00:05:00Z", actor: "owner:release", settings: { ...actions, can_approve_pull_request_reviews: true } });
+    await writeFile(settingsPath, JSON.stringify({ ...settings, actions: record.settings, admin_attestation: { status: "current", record } }));
+    assert.ok((await validateReleaseCandidateEvidence(candidate, mutationTrusted)).some((failure) => failure.includes("attestation")), mutation);
+  }
 
   const selfAttested = { ...evidence, artifacts: { first_sha256: "b".repeat(64) } };
   await writeFile(resolve(candidate, "distribution/release/release-candidate-evidence.json"), `${JSON.stringify(selfAttested)}\n`);
   assert.ok((await validateReleaseCandidateEvidence(candidate, trusted)).some((failure) => failure.includes("contract")));
+});
+
+test("REQ-RELEASE-001 admin settings attestation rejects forgery, staleness, wrong repository, and weakened policy", () => {
+  const settings = { default_workflow_permissions: "read", can_approve_pull_request_reviews: false };
+  const record = issueAdminSettingsAttestation({ repository: "aithinkers/knowledge-dlc", capturedAt: "2026-08-15T00:00:00Z", confirmedAt: "2026-08-15T00:05:00Z", actor: "owner:release", settings });
+  const options = { repository: "aithinkers/knowledge-dlc", now: "2026-08-15T12:00:00Z" };
+  assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(record), options).status, "current");
+  assert.equal(evaluateAdminSettingsAttestation(JSON.stringify({ ...record, settings: { ...settings, default_workflow_permissions: "write" } }), options).status, "invalid");
+  assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(record), { ...options, now: "2026-08-16T00:00:00.001Z" }).status, "stale");
+  assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(record), { ...options, repository: "attacker/fork" }).status, "invalid");
+  assert.equal(evaluateAdminSettingsAttestation(JSON.stringify({ ...record, manual_cross_check: { ...record.manual_cross_check, method: "caller-claim" } }), options).status, "invalid");
+  const beforeCapture = issueAdminSettingsAttestation({ repository: options.repository, capturedAt: "2026-08-15T00:05:00Z", confirmedAt: "2026-08-15T00:00:00Z", actor: "owner:release", settings });
+  assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(beforeCapture), options).status, "invalid");
+  const weakened = issueAdminSettingsAttestation({ repository: options.repository, capturedAt: "2026-08-15T00:00:00Z", confirmedAt: "2026-08-15T00:05:00Z", actor: "owner:release", settings: { ...settings, can_approve_pull_request_reviews: true } });
+  assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(weakened), options).status, "weakened");
+  assert.equal(evaluateAdminSettingsAttestation("", options).status, "unavailable");
+  assert.equal(evaluateAdminSettingsAttestation("{", options).status, "invalid");
 });
 
 test("REL-001 live ruleset derivation respects exact ref exclusions and composes split effective rules", () => {

--- a/tests/governance/release-candidate-evidence.test.mjs
+++ b/tests/governance/release-candidate-evidence.test.mjs
@@ -77,6 +77,8 @@ test("REQ-RELEASE-001 admin settings attestation rejects forgery, staleness, wro
   assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(beforeCapture), options).status, "invalid");
   const futureConfirmation = attest({ repository: options.repository, confirmedAt: "2026-08-15T13:00:00Z", settings });
   assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(futureConfirmation), options).status, "invalid");
+  const lateConfirmation = attest({ repository: options.repository, confirmedAt: "2026-08-15T01:00:00.001Z", settings });
+  assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(lateConfirmation), options).status, "invalid");
   const autoConfirmed = attest({ repository: options.repository, confirmedAt: "2026-08-15T00:00:00Z", settings });
   assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(autoConfirmed), options).status, "invalid");
   const capture = createAdminSettingsCapture({ repository: options.repository, capturedAt: "2026-08-15T00:00:00Z", actor: "release-owner", responseBytes: Buffer.from(JSON.stringify(settings)) });

--- a/tests/governance/release-candidate-evidence.test.mjs
+++ b/tests/governance/release-candidate-evidence.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import test from "node:test";
@@ -73,6 +73,8 @@ test("REQ-RELEASE-001 admin settings attestation rejects forgery, staleness, wro
   assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(record), { ...options, now: "2026-08-16T00:00:00.001Z" }).status, "stale");
   assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(record), { ...options, repository: "attacker/fork" }).status, "invalid");
   assert.equal(evaluateAdminSettingsAttestation(JSON.stringify({ ...record, manual_cross_check: { ...record.manual_cross_check, method: "caller-claim" } }), options).status, "invalid");
+  const hostileOrigin = structuredClone(record); hostileOrigin.capture.api_origin = "https://github.enterprise.invalid/api/v3";
+  assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(hostileOrigin), options).status, "invalid");
   const beforeCapture = attest({ repository: options.repository, capturedAt: "2026-08-15T00:05:00Z", confirmedAt: "2026-08-15T00:00:00Z", settings });
   assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(beforeCapture), options).status, "invalid");
   const futureConfirmation = attest({ repository: options.repository, confirmedAt: "2026-08-15T13:00:00Z", settings });
@@ -90,6 +92,12 @@ test("REQ-RELEASE-001 admin settings attestation rejects forgery, staleness, wro
   assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(weakened), options).status, "weakened");
   assert.equal(evaluateAdminSettingsAttestation("", options).status, "unavailable");
   assert.equal(evaluateAdminSettingsAttestation("{", options).status, "invalid");
+});
+
+test("REQ-RELEASE-001 hostile GH_HOST cannot redirect owner capture or confirmation authority", async () => {
+  const utility = await readFile(resolve(root, "scripts/create-admin-settings-attestation.mjs"), "utf8");
+  assert.equal((utility.match(/\["api", "--hostname", "github\.com"/gu) ?? []).length, 2);
+  assert.doesNotMatch(utility, /process\.env\.GH_HOST/u);
 });
 
 test("REL-001 live ruleset derivation respects exact ref exclusions and composes split effective rules", () => {

--- a/tests/governance/release-candidate-evidence.test.mjs
+++ b/tests/governance/release-candidate-evidence.test.mjs
@@ -6,12 +6,17 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 import { validateReleaseCandidateEvidence } from "../../scripts/release-evidence-validation.mjs";
-import { deriveRulesetState, evaluateAdminSettingsAttestation, issueAdminSettingsAttestation } from "../../scripts/release-state-derivation.mjs";
+import { createAdminSettingsCapture, deriveRulesetState, evaluateAdminSettingsAttestation, issueAdminSettingsAttestation } from "../../scripts/release-state-derivation.mjs";
 
 const root = resolve(import.meta.dirname, "../.."); const hash = (bytes) => `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
 const cells = ["ubuntu-node22", "ubuntu-node24", "windows-node22", "windows-node24", "macos-node22", "macos-node24"];
 const observed = { package: { first_sha256: "b".repeat(64), second_sha256: "b".repeat(64), manifest_sha256: "c".repeat(64), content_sha256: "f".repeat(64), file_count: 178 }, supply_chain: { sbom_sha256: "d".repeat(64), notices_sha256: "e".repeat(64) }, smoke: { cli: true, imports: true } };
 const matrix = (head) => cells.map((cell) => ({ cell, head_sha: head, platform: { os: cell.startsWith("windows") ? "win32" : cell.startsWith("macos") ? "darwin" : "linux" }, observed_evidence: structuredClone(observed) }));
+const attest = ({ repository = "aithinkers/knowledge-dlc", capturedAt = "2026-08-15T00:00:00Z", confirmedAt = "2026-08-15T00:05:00Z", actor = "release-owner", settings }) => {
+  const responseBytes = Buffer.from(JSON.stringify(settings));
+  const capture = createAdminSettingsCapture({ repository, capturedAt, actor, responseBytes });
+  return issueAdminSettingsAttestation({ capture, confirmedAt, actor });
+};
 
 test("REL-001 release-candidate gate derives package, supply-chain, settings, and independent review evidence outside candidate records", async (context) => {
   const candidate = await mkdtemp(resolve(tmpdir(), "kdlc-candidate-evidence-")); context.after(() => rm(candidate, { recursive: true, force: true }));
@@ -24,7 +29,7 @@ test("REL-001 release-candidate gate derives package, supply-chain, settings, an
   await writeFile(resolve(candidate, "distribution/release/release-candidate-evidence.json"), `${JSON.stringify(evidence, null, 2)}\n`);
   const settingsPath = resolve(candidate, "settings.json"); const reviewPath = resolve(candidate, "review.json");
   const actions = { default_workflow_permissions: "read", can_approve_pull_request_reviews: false };
-  const attestation = issueAdminSettingsAttestation({ repository: "aithinkers/knowledge-dlc", capturedAt: "2026-08-15T00:00:00Z", confirmedAt: "2026-08-15T00:05:00Z", actor: "owner:release", settings: actions });
+  const attestation = attest({ settings: actions });
   const settings = { visibility: "public", actions, admin_attestation: { status: "current", record: attestation }, release_blocking_issues_closed: true, ruleset: { ids: [1], active: true, default_branch: true, prevents_deletion: true, prevents_non_fast_forward: true, linear_history: true, pull_request: { required_approvals: 1, require_code_owner_review: true, dismiss_stale_reviews: true, require_last_push_approval: true, require_thread_resolution: true, allowed_merge_methods: ["squash"] }, strict_status_checks: true, required_checks: ["Candidate tests", "CodeQL (JavaScript/TypeScript)", "Dependency review", "Pull request traceability", "Release matrix", "Repository policy", "Secret history scan", "Supply-chain verification"], direct_push_bypass: false } };
   const review = { head_sha: head, decision: "approved", evidence_kind: "independent-agent-comment", evidence_id: 42, evidence_url: "https://github.test/review/42", actor: "review-agent", observed_at: "2026-08-15T00:00:00Z" };
   await writeFile(settingsPath, JSON.stringify(settings)); await writeFile(reviewPath, JSON.stringify(review));
@@ -48,8 +53,8 @@ test("REL-001 release-candidate gate derives package, supply-chain, settings, an
     let record = structuredClone(attestation); let mutationTrusted = trusted;
     if (mutation === "stale") mutationTrusted = { ...trusted, now: "2026-08-16T00:00:00.001Z" };
     if (mutation === "forged") record.settings.default_workflow_permissions = "write";
-    if (mutation === "wrong-repository") record = issueAdminSettingsAttestation({ repository: "attacker/fork", capturedAt: "2026-08-15T00:00:00Z", confirmedAt: "2026-08-15T00:05:00Z", actor: "owner:release", settings: actions });
-    if (mutation === "weakened") record = issueAdminSettingsAttestation({ repository: trusted.repository, capturedAt: "2026-08-15T00:00:00Z", confirmedAt: "2026-08-15T00:05:00Z", actor: "owner:release", settings: { ...actions, can_approve_pull_request_reviews: true } });
+    if (mutation === "wrong-repository") record = attest({ repository: "attacker/fork", settings: actions });
+    if (mutation === "weakened") record = attest({ repository: trusted.repository, settings: { ...actions, can_approve_pull_request_reviews: true } });
     await writeFile(settingsPath, JSON.stringify({ ...settings, actions: record.settings, admin_attestation: { status: "current", record } }));
     assert.ok((await validateReleaseCandidateEvidence(candidate, mutationTrusted)).some((failure) => failure.includes("attestation")), mutation);
   }
@@ -61,16 +66,25 @@ test("REL-001 release-candidate gate derives package, supply-chain, settings, an
 
 test("REQ-RELEASE-001 admin settings attestation rejects forgery, staleness, wrong repository, and weakened policy", () => {
   const settings = { default_workflow_permissions: "read", can_approve_pull_request_reviews: false };
-  const record = issueAdminSettingsAttestation({ repository: "aithinkers/knowledge-dlc", capturedAt: "2026-08-15T00:00:00Z", confirmedAt: "2026-08-15T00:05:00Z", actor: "owner:release", settings });
+  const record = attest({ settings });
   const options = { repository: "aithinkers/knowledge-dlc", now: "2026-08-15T12:00:00Z" };
   assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(record), options).status, "current");
   assert.equal(evaluateAdminSettingsAttestation(JSON.stringify({ ...record, settings: { ...settings, default_workflow_permissions: "write" } }), options).status, "invalid");
   assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(record), { ...options, now: "2026-08-16T00:00:00.001Z" }).status, "stale");
   assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(record), { ...options, repository: "attacker/fork" }).status, "invalid");
   assert.equal(evaluateAdminSettingsAttestation(JSON.stringify({ ...record, manual_cross_check: { ...record.manual_cross_check, method: "caller-claim" } }), options).status, "invalid");
-  const beforeCapture = issueAdminSettingsAttestation({ repository: options.repository, capturedAt: "2026-08-15T00:05:00Z", confirmedAt: "2026-08-15T00:00:00Z", actor: "owner:release", settings });
+  const beforeCapture = attest({ repository: options.repository, capturedAt: "2026-08-15T00:05:00Z", confirmedAt: "2026-08-15T00:00:00Z", settings });
   assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(beforeCapture), options).status, "invalid");
-  const weakened = issueAdminSettingsAttestation({ repository: options.repository, capturedAt: "2026-08-15T00:00:00Z", confirmedAt: "2026-08-15T00:05:00Z", actor: "owner:release", settings: { ...settings, can_approve_pull_request_reviews: true } });
+  const futureConfirmation = attest({ repository: options.repository, confirmedAt: "2026-08-15T13:00:00Z", settings });
+  assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(futureConfirmation), options).status, "invalid");
+  const autoConfirmed = attest({ repository: options.repository, confirmedAt: "2026-08-15T00:00:00Z", settings });
+  assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(autoConfirmed), options).status, "invalid");
+  const capture = createAdminSettingsCapture({ repository: options.repository, capturedAt: "2026-08-15T00:00:00Z", actor: "release-owner", responseBytes: Buffer.from(JSON.stringify(settings)) });
+  assert.throws(() => issueAdminSettingsAttestation({ capture, confirmedAt: "2026-08-15T00:05:00Z", actor: "wrong-owner" }), /unauthorized/u);
+  const staleCachedCapture = createAdminSettingsCapture({ repository: options.repository, capturedAt: "2026-08-13T00:00:00Z", actor: "release-owner", responseBytes: Buffer.from(JSON.stringify(settings)) });
+  const staleCachedRecord = issueAdminSettingsAttestation({ capture: staleCachedCapture, confirmedAt: "2026-08-13T00:05:00Z", actor: "release-owner" });
+  assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(staleCachedRecord), options).status, "stale");
+  const weakened = attest({ repository: options.repository, settings: { ...settings, can_approve_pull_request_reviews: true } });
   assert.equal(evaluateAdminSettingsAttestation(JSON.stringify(weakened), options).status, "weakened");
   assert.equal(evaluateAdminSettingsAttestation("", options).status, "unavailable");
   assert.equal(evaluateAdminSettingsAttestation("{", options).status, "invalid");

--- a/tests/governance/release-matrix.test.mjs
+++ b/tests/governance/release-matrix.test.mjs
@@ -20,6 +20,7 @@ test("REL-001 release matrix declares exact six platform/runtime cells and stabl
   assert.deepEqual(new Set(releaseMatrixCells.map(({ os }) => os)), new Set(["linux", "win32", "darwin"]));
   assert.deepEqual(releaseMatrixCommandIds, ["full", "offline", "release", "statistical", "clean-rebuild", "supply-chain", "pack", "cli", "import"]);
   const workflow = await readFile(resolve(root, ".github/workflows/release-matrix.yml"), "utf8");
+  const collector = await readFile(resolve(root, "scripts/collect-release-state.mjs"), "utf8");
   const derivationSource = await readFile(resolve(root, "scripts/derive-release-artifacts.mjs"), "utf8");
   const attributes = await readFile(resolve(root, ".gitattributes"), "utf8");
   const parsedWorkflow = parseYamlArtifact(workflow);
@@ -43,6 +44,9 @@ test("REL-001 release matrix declares exact six platform/runtime cells and stabl
   assert.equal(stateSteps.filter((step) => step.uses?.startsWith("actions/checkout@")).length, 1);
   assert.equal(stateSteps.find((step) => step.name === "Check out trusted release-state collector").with.ref, "${{ github.event.pull_request.base.sha || github.sha }}");
   assert.match(stateSteps.find((step) => step.name === "Collect live state without candidate checkout or execution").run, /node trusted\/scripts\/collect-release-state\.mjs/);
+  assert.equal(stateSteps.find((step) => step.name === "Collect live state without candidate checkout or execution").env.KDLC_ADMIN_SETTINGS_ATTESTATION, "${{ vars.KDLC_ADMIN_SETTINGS_ATTESTATION }}");
+  assert.doesNotMatch(collector, /actions\/permissions\/workflow/);
+  assert.match(collector, /evaluateAdminSettingsAttestation/);
 });
 
 test("REL-001 release matrix aggregator rejects missing or substituted cells", async (context) => {


### PR DESCRIPTION
Closes #44

## Requirement IDs

- Requirement IDs: REQ-RELEASE-001

## Traceability

- Issue: #44
- Requirement: REQ-RELEASE-001
- Release requirement: REL-001
- Exact base: `3f64a1af3e638e01a5160ed0c3a886edc3e7cdb4`
- Exact implementation head: `f422fb5127107fb67992d410dbbbe0c38582d070`
- Bootstrap contract: PR #47 exact head `9cd275b470a2a597ece0823fe4cf2413593320a6`

## Specification

- Knowledge Development Lifecycle Specification §§35–36
- AGENTS.md protected transition, independent review, and audited bypass requirements

## Outcome

The trusted-base release-state job no longer asks its minimal `GITHUB_TOKEN` for the administration-only Actions workflow-permissions endpoint. Public repository, ruleset, issue, review, and check facts remain live GitHub API-derived. Administration settings come from a two-step owner-controlled flow: authenticated live capture pinned to `github.com`/`https://api.github.com`, followed by separate same-owner manual confirmation. The record binds repository, origin, endpoint, response bytes/hash, capture provenance, strict times, actor, settings, and canonical hashes.

Missing or stale evidence leaves prerelease verification operable. A release candidate fails closed unless evidence is authentic, exact-repository and exact-origin bound, freshly captured, separately confirmed, and preserves read-only defaults with workflow PR approval disabled. Candidate code is never checked out or executed in the token/attestation job.

## Five gates

1. Feature definition: issue #44 records requirements, acceptance criteria, risks, dependencies, and specification references.
2. Plan review: privileged collection stays outside Actions; public facts remain token-derived.
3. Development: trusted collector, validator, two-step owner utility, workflow binding, documentation, and traceability are implemented.
4. Testing: stale cache, forged bytes/hashes, wrong repository/origin/actor, automatic/future/late confirmation, and weakened policy fail closed.
5. Final review: remains draft until contract PR #47 merges; independent exact-head review is required afterward.

## Commands and results:

```text
Node v24.5.0 / npm 11.5.1
npm test
  PASS — 204/204
node --test tests/governance/release-candidate-evidence.test.mjs
  PASS — 4/4
npm run test:release-evaluation
  PASS — 9/9 recorded offline cases
npm run check:release-evidence
  PASS
npm run check:supply-chain
  PASS — 17 dependencies, 18 relationships, 178 package paths
npm run check:distribution
  PASS
npm audit --audit-level=high
  PASS — 0 vulnerabilities
actionlint v1.7.7
  PASS
gitleaks full-history scan
  PASS
npm pack --dry-run --json --ignore-scripts
  PASS — 178 exact files
git diff --check
  PASS
GH_HOST=github.enterprise.invalid node scripts/create-admin-settings-attestation.mjs capture ...
  PASS — live pending record remained bound to https://api.github.com and mode 0600
```

## Protected transition

This PR changes the four protected release-state files exact-bound in PR #47. Until that contract reaches `main`, `Repository policy` is expected to reject those byte differences. `Trusted release state` and aggregate `Release matrix` also fail because trusted current `main` still executes the superseded administration endpoint. No other failure is authorized.

After PR #47 merges, this head must remain unchanged. Candidate tests and all non-self security checks must pass, an independent agent must approve this exact head with no unresolved high/critical finding, and the owner exception must record only contract-authorized self-transition failures.

## Risk and rollback

Risks include stale evidence, origin confusion, forged bindings, weakened Actions defaults, or authority exposure to candidate code. Exact structure/hash/repository/origin/time/policy checks, owner reauthentication, trusted-base execution, and the no-candidate token job constrain them. Rollback is a revert and repository-variable removal; release-candidate validation remains fail closed.

I will not self-review, approve, or merge.
