### PR TITLE
docs: authorize one-time admin attestation bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,39 @@ identify that self-difference as its sole failed check and bypass reason. This
 authority is consumed and expires immediately when PR #39 merges, and it does
 not authorize any later harness, reporter, workflow, or verifier change.
 
+PR #45, linked to issue #44, may use a one-time protected release-state
+bootstrap bypass only at head
+`8761b9ea01e3db3025d86b0ff5a78aa55295c0e7`. It authorizes exactly these
+SHA-256 transitions:
+
+- `.github/workflows/release-matrix.yml` from
+  `637ae1155eabde7e3d53cf29fb157d5177113d2c4482adfe5dcd5ab975587fcc`
+  to `3e03834c1d4d9bc9c12bde39d22bdbfbf9d09da8196984faeef3dc01ad4acfb1`;
+- `scripts/collect-release-state.mjs` from
+  `f07e557073978f722136d59cb4af0f29eb8a5b553eee227735065f1d9f4a1b3c`
+  to `1fc144b0954e543c94efeb8b4719dfb478f97f54da2d52b4808b6749b1539d7c`;
+- `scripts/release-state-derivation.mjs` from
+  `db94d015dd3ab409eac9b2c43af5c991dedf5e3a4cd893285af5c54c6f727a34`
+  to `44d82a36bec486c8c54d2f3a6ba26602edad6f036392ae208f46045625bca6a5`;
+- `scripts/release-evidence-validation.mjs` from
+  `3d4e224165a5296f3baf7e5f8a2e0302e5e52baff586eadcddb8b4552b40639d`
+  to `f8696009967ff88106a9fbaafbacf1c4479a0dbedd11e141d46ac6f22ea06cb3`.
+
+The complete PR diff is limited to those protected transitions, the new local
+owner capture utility, issue #44 tests and documentation, traceability, and
+mechanical conformance hashes. Candidate tests and every non-self security
+check must pass, the full six-cell matrix must pass locally, and an independent
+agent must approve the exact head with no unresolved critical or high finding.
+Only `Repository policy` protected-byte rejection and the `Trusted release
+state`/aggregate `Release matrix` failures caused by trusted `main` executing
+the superseded administration endpoint may be bypassed; the owner record must
+name each as a self-transition failure. Candidate code must never execute in
+the token/attestation job, and this exception does not authorize trigger,
+permission, toolchain, candidate-test, governance-verifier, or unrelated
+release-gate changes. This authority is consumed and expires immediately when
+PR #45 merges. A subsequent ordinary PR must demonstrate green `Trusted release
+state` and `Release matrix` before issue #44 is treated as fully verified.
+
 Repository administrators, write collaborators, and repository-configured
 GitHub Actions are inside the current CI trust boundary. Bare commit-status
 contexts are therefore enforcement against ordinary candidate changes, not a


### PR DESCRIPTION
Progresses #44; this contract must merge before implementation PR #45. PR #45 remains the closing implementation tranche.

## Requirement

- `REQ-RELEASE-001`
- REL-001; K-DLC §§35–36
- Contract base: `3f64a1af3e638e01a5160ed0c3a886edc3e7cdb4`

## One-time contract

This AGENTS-only change authorizes implementation PR #45 only at exact head `8761b9ea01e3db3025d86b0ff5a78aa55295c0e7` and binds the exact before/after SHA-256 values of all four protected files:

- `.github/workflows/release-matrix.yml`: `637ae115…` → `3e03834c…`
- `scripts/collect-release-state.mjs`: `f07e5570…` → `1fc144b0…`
- `scripts/release-state-derivation.mjs`: `db94d015…` → `44d82a36…`
- `scripts/release-evidence-validation.mjs`: `3d4e2241…` → `f8696009…`

The committed contract contains the complete hashes. It limits the rest of PR45 to the owner capture utility, #44 tests/documentation/traceability, and mechanical conformance hashes. It requires candidate and non-self security checks, local full six-cell verification, and independent approval at the exact head with no unresolved high/critical finding. It forbids trigger, permission, toolchain, candidate-test, governance-verifier, and unrelated release-gate changes.

Only these trusted-base self-transition failures may be recorded for an audited owner exception: protected-byte `Repository policy`, and `Trusted release state`/aggregate `Release matrix` failures caused by trusted main calling the superseded administration endpoint. Authority expires immediately on PR45 merge, and an ordinary subsequent PR must prove both live-state checks green before #44 is treated as fully verified.

## Verification

- Node v24.5.0 / npm 11.5.1
- `npm test` — 202/202 passed
- `npm run test:release-evaluation` — 9/9 passed offline
- `npm run check:release-evidence`
- `npm run check:supply-chain`
- `npm run check:distribution`
- `npm audit --audit-level=high` — 0 vulnerabilities
- actionlint v1.7.7
- Gitleaks full-history scan — no leaks
- `git diff --check`

## Risk and rollback

Exact file hashes, head binding, narrow allowed diff, explicit self-failures, independent review, and immediate expiry prevent reuse or broadening. Rollback is a one-file revert before PR45 merges. This PR changes no workflow, collector, verifier, permissions, token boundary, or candidate code.

I will not self-review, approve, or merge.
