### PR TITLE
fix: install trusted release collector dependencies (#44)

### DIFF
--- a/.github/workflows/release-matrix.yml
+++ b/.github/workflows/release-matrix.yml
@@ -62,6 +62,14 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha || github.sha }}
           path: trusted
           persist-credentials: false
+      - name: Set up trusted collector runtime
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.5.0
+          cache: npm
+          cache-dependency-path: trusted/package-lock.json
+      - name: Install trusted locked dependencies without lifecycle scripts
+        run: npm ci --ignore-scripts --prefix trusted
       - name: Collect live state without candidate checkout or execution
         shell: bash
         env:

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -234,7 +234,7 @@
       "title": "Bind administration-only release settings through owner attestation",
       "issue": 44,
       "specification_sections": ["35", "36"],
-      "status": "implemented",
+      "status": "in-progress",
       "evidence": {
         "implementation": [
           ".github/workflows/release-matrix.yml",

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -234,7 +234,7 @@
       "title": "Bind administration-only release settings through owner attestation",
       "issue": 44,
       "specification_sections": ["35", "36"],
-      "status": "in-progress",
+      "status": "implemented",
       "evidence": {
         "implementation": [
           ".github/workflows/release-matrix.yml",

--- a/tests/governance/release-matrix.test.mjs
+++ b/tests/governance/release-matrix.test.mjs
@@ -43,6 +43,14 @@ test("REL-001 release matrix declares exact six platform/runtime cells and stabl
   const stateSteps = parsedWorkflow.jobs["release-state"].steps;
   assert.equal(stateSteps.filter((step) => step.uses?.startsWith("actions/checkout@")).length, 1);
   assert.equal(stateSteps.find((step) => step.name === "Check out trusted release-state collector").with.ref, "${{ github.event.pull_request.base.sha || github.sha }}");
+  const stateInstall = stateSteps.find((step) => step.name === "Install trusted locked dependencies without lifecycle scripts");
+  assert.equal(stateInstall.run, "npm ci --ignore-scripts --prefix trusted");
+  assert.equal(stateInstall.env, undefined);
+  assert.equal(stateSteps.findIndex((step) => step.name === "Install trusted locked dependencies without lifecycle scripts")
+    < stateSteps.findIndex((step) => step.name === "Collect live state without candidate checkout or execution"), true);
+  const stateRuntime = stateSteps.find((step) => step.name === "Set up trusted collector runtime");
+  assert.equal(stateRuntime.with["cache-dependency-path"], "trusted/package-lock.json");
+  assert.doesNotMatch(JSON.stringify(parsedWorkflow.jobs["release-state"]), /pull_request\.head|github\.sha[^}]*head/u);
   assert.match(stateSteps.find((step) => step.name === "Collect live state without candidate checkout or execution").run, /node trusted\/scripts\/collect-release-state\.mjs/);
   assert.equal(stateSteps.find((step) => step.name === "Collect live state without candidate checkout or execution").env.KDLC_ADMIN_SETTINGS_ATTESTATION, "${{ vars.KDLC_ADMIN_SETTINGS_ATTESTATION }}");
   assert.doesNotMatch(collector, /actions\/permissions\/workflow/);


### PR DESCRIPTION
Closes #44

## Requirement IDs

- Requirement IDs: REQ-RELEASE-001

## Traceability

- Issue: #44
- Exact base: `264daf94f05cb9c853d83a04fafb9de5f699521b`
- Exact implementation head: `ade72cceea998ad7e5bbedfe58dac59f09476b6c`
- Protected workflow transition: `.github/workflows/release-matrix.yml` from `3e03834c1d4d9bc9c12bde39d22bdbfbf9d09da8196984faeef3dc01ad4acfb1` to `683eedf931a101b61316a73518df8b296fa71c225302a1b78632ed7eb49eeb52`

## Specification

- Knowledge Development Lifecycle Specification §§35–36
- AGENTS.md protected transition and audited bypass requirements

## Change

- Sets up pinned Node 24.5.0 only after the trusted-base checkout.
- Runs `npm ci --ignore-scripts --prefix trusted` against the trusted base lockfile before invoking its collector.
- Keeps the dependency-install step tokenless; `GH_TOKEN` and owner attestation remain scoped only to the collector step.
- Retains exactly one checkout in the token-bearing job, pinned to the PR base SHA; candidate dependencies and scripts are never checked out or executed.
- Adds structural regressions for trusted lockfile binding, step order, token isolation, and absence of candidate-head checkout.

## Commands and results:

```text
Node v24.5.0 / npm 11.5.1
node --test tests/governance/release-matrix.test.mjs
  PASS — 4/4
npm test
  PASS — 204/204
npm run test:release-evaluation
  PASS — 9/9
npm run check:release-evidence
  PASS
npm run check:supply-chain
  PASS — 17 dependencies, 18 relationships, 178 package paths
npm run check:distribution
  PASS
npm audit --audit-level=high
  PASS — 0 vulnerabilities
git diff --check
  PASS
actionlint
  NOT RUN locally — executable unavailable; hosted workflow validation required
```

## Protected bootstrap

A separate AGENTS-only exact-head contract is required before this workflow change can merge. Until then, `Repository policy` is expected to reject the workflow byte change. `Trusted release state` and aggregate `Release matrix` are expected to fail because trusted current `main` still lacks this dependency installation. No other failure is authorized.

## Risk and rollback

The risk is executing candidate dependencies in a token-bearing job. The job checks out only trusted base, installation is lockfile-bound with lifecycle scripts disabled and no token environment, and only the later collector step receives read token/attestation inputs. Rollback reverts the workflow/test commit; the release gate then fails closed with the known missing dependency.

No self-review or merge.
