### PR TITLE
docs: restructure README around agent-consumable knowledge (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,111 @@
-# K-DLC
+# K-DLC — turn your documents into agent-consumable knowledge
 
-K-DLC (Knowledge Development Lifecycle) is a harness-neutral lifecycle and
-governance framework for building, querying, and maintaining agent-authored
-knowledge bases.
+**K-DLC (Knowledge Development Lifecycle)** turns the documents your team
+already has — wikis, PDFs, spreadsheets, decks, diagrams — into durable,
+provenance-bearing knowledge that AI agents can actually trust: curated, linked
+Markdown concepts in the [Open Knowledge Format (OKF)](core/schemas/okf-0.2/),
+produced through a governed lifecycle with explicit human approval gates.
 
-The public repository is in pre-release MVP development against specification
-version 0.2.0. It is not a supported release. Conformance is declared
-module-by-module; no module or document-format capability is considered
-implemented until its linked issue, tests, and independent review evidence are
-complete.
-
-## Development status
-
-- [MVP milestone](https://github.com/aithinkers/knowledge-dlc/milestone/1)
-- [Requirement and feature backlog](https://github.com/aithinkers/knowledge-dlc/issues)
-- [Specification baseline](docs/specification-baseline.md)
-- [Traceability index](docs/traceability.json)
-- [Agent development contract](AGENTS.md)
-- [Development harness](development/README.md)
-- [Contributing guide](CONTRIBUTING.md)
-- [Security policy](SECURITY.md)
-- [Support policy](SUPPORT.md)
-- [Code of Conduct](CODE_OF_CONDUCT.md)
-- [Release-readiness gates](docs/release-readiness.md)
-- [Machine-readable pre-release conformance](distribution/release/conformance-statement.json)
-- [Recorded pre-release evaluation](distribution/release/evaluation-report.json)
-
-## Required delivery flow
+One harness-neutral core, rendered natively for **Claude Code, Codex CLI,
+Kiro CLI, Kiro IDE, and any MCP client** — the same governed engine, the same
+versioned envelope, everywhere.
 
 ```text
-requirement -> GitHub issue -> reviewed plan -> implementation -> tests
-            -> independent review -> pull request -> release evidence
+Sources -> Evidence -> Claims -> Concepts -> Published knowledge
+                 \       |          |
+                  \------ provenance + review receipts
 ```
 
-Every change must begin with an issue and preserve that relationship through
-the branch, commits, pull request, tests, and traceability index. CI enforces
-the machine-checkable parts of this contract.
+> [!NOTE]
+> This repository is in pre-release MVP development against specification
+> version 0.2.0. It is not a supported release. Conformance is declared
+> module-by-module; no capability is considered implemented until its linked
+> issue, tests, and independent review evidence are complete.
+
+> [!IMPORTANT]
+> Generative AI can make mistakes. K-DLC never publishes stable knowledge on
+> model confidence alone — review the evidence, claims, and diffs its gates
+> put in front of you.
+
+## Why K-DLC
+
+Retrieval over raw documents works until the corpus gets real. Then agents cite
+stale pages, contradictions surface mid-answer, and nobody can say where a
+"fact" came from. K-DLC puts structure around knowledge the way CI puts
+structure around code: every claim traces to a source hash and locator,
+every concept records who generated and who verified it, conflicts are
+retained instead of silently resolved, and publication is a reviewed, atomic
+transaction. Search indexes, embeddings, and graphs stay rebuildable
+projections — plain files remain the durable contract.
+
+## Key features
+
+- **Evidence-first ingestion** — bounded, sandboxed normalization of Markdown,
+  text, CSV, PDF, Office, diagrams, and media into anchored, quality-labeled
+  evidence units ([spec §12](docs/knowledge-development-lifecycle-specification.md))
+- **Claim-to-source provenance** — every assertion carries its source ID,
+  version hash, and locator; inferred claims are never dressed up as explicit
+  statements
+- **Governed lifecycle** — fifteen core stages across Define → Acquire →
+  Understand → Integrate → Govern, with review packets, receipts bound to exact
+  review hashes, and transactional publication
+- **Nine-role agent roster** — conductor, curator, source-analyst, integrator,
+  librarian, trust-reviewer, retrieval-agent, maintainer, governance-reviewer —
+  with runtime-enforced read/write capabilities, not prompt-text promises
+- **Federation** — mount multiple knowledge bases with explicit modes, locked
+  versions, and routing; retrieval rank never grants write authority
+- **Access-intersection answers** — a query result is allowed only when the
+  requester may see the concept *and* all evidence it discloses
+- **Deterministic governance** — sensors, audit trails, traceability, and a
+  release evaluation that runs with zero live model calls
+
+## Pick your harness
+
+| Harness | Install | Invoke |
+| --- | --- | --- |
+| **Claude Code** | `claude plugin install <repo>/distribution/claude-code` | `/kdlc:<operation>`, `kdlc:<role>` agents |
+| **Codex CLI** (≥ 0.145) | copy `distribution/codex/` conventions | `$kdlc` skill, `.codex/agents/<role>` |
+| **Kiro CLI** (≥ 2.6) | copy `distribution/kiro/.kiro/` into your project | `/kdlc-<operation>`, `.kiro/agents/<role>` |
+| **Kiro IDE** | copy `distribution/kiro-ide/.kiro/` into your project | `/kdlc-<operation>`, `.kiro/agents/<role>` |
+| **Any MCP client** | `distribution/mcp/desktop.json` (stdio) / `custom-app.json` (HTTP) | `kb_search`, `kb_fetch`, `proposal_create`, … |
+
+Adapters differ only in packaging: stage requirements, security policy, state
+transitions, and artifact contracts are identical everywhere (spec §25), and
+every distribution tree is generated from the authored core — CI fails on
+drift.
+
+## Quick start
+
+```bash
+npm ci && npm link     # exposes the `kdlc` CLI
+mkdir my-knowledge && cd my-knowledge
+kdlc init              # scaffold a governed project workspace
+kdlc ingest notes.md   # normalize a source into anchored evidence
+kdlc query "what do we know about tokens?"
+```
+
+The full walkthrough — install, ingest, review, publish, plugin and MCP
+setup — lives in **[docs/getting-started.md](docs/getting-started.md)** and is
+executed end-to-end by a test on every change.
+
+## Repository layout
+
+Schemas and profiles live under `core/`; stage, agent, sensor, tool,
+normalizer, and server sources live under `packages/`; generated harness
+output lives under `distribution/<harness>/`. The complete mapping from the
+specification's reference layout is recorded in
+[ADR-002](docs/decisions/0002-repository-layout-mapping.md).
+
+## Development status and governance
+
+- [Specification baseline](docs/specification-baseline.md) ([full spec](docs/knowledge-development-lifecycle-specification.md))
+- [MVP milestone](https://github.com/aithinkers/knowledge-dlc/milestone/1) and [issue backlog](https://github.com/aithinkers/knowledge-dlc/issues)
+- [Traceability index](docs/traceability.json)
+- [Agent development contract](AGENTS.md) — issue → plan → implementation → tests → independent review → release evidence
+- [Release-readiness gates](docs/release-readiness.md)
+- [Machine-readable pre-release conformance](distribution/release/conformance-statement.json) (status: not-ready)
+- [Recorded pre-release evaluation](distribution/release/evaluation-report.json) — zero live model calls
+- [Contributing](CONTRIBUTING.md) · [Security policy](SECURITY.md) · [Support](SUPPORT.md) · [Code of Conduct](CODE_OF_CONDUCT.md)
 
 ## Local governance checks
 

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -16,5 +16,5 @@
   "pending_requirements": [
     {"id": "REL-001", "issue": 10, "reason": "Statistical evaluation, final artifact/version agreement, external protections, and independent release verification remain pending.", "release_blocking": true}
   ],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:b4ae0c7faa381e33adea95155c3c7e1d5eedf363bb5826735670aa299e8d10d0"},{"path":"docs/traceability.json","sha256":"sha256:e972ca9f34d56cf0ede7877177131966e9cdd93e98a3e3bf4efddf634d74ce4f"},{"path":"docs/release-readiness.md","sha256":"sha256:50fde18197710993f13ab039beff4f08173c035678472cd40396f10f3a22234c"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:b4ae0c7faa381e33adea95155c3c7e1d5eedf363bb5826735670aa299e8d10d0"},{"path":"docs/traceability.json","sha256":"sha256:8b299c21c6d7f6fa77dda2a4b886d98e5be40052563b7d8814b469613870d74c"},{"path":"docs/release-readiness.md","sha256":"sha256:50fde18197710993f13ab039beff4f08173c035678472cd40396f10f3a22234c"}]
 }

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -16,5 +16,5 @@
   "pending_requirements": [
     {"id": "REL-001", "issue": 10, "reason": "Statistical evaluation, final artifact/version agreement, external protections, and independent release verification remain pending.", "release_blocking": true}
   ],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:b4ae0c7faa381e33adea95155c3c7e1d5eedf363bb5826735670aa299e8d10d0"},{"path":"docs/traceability.json","sha256":"sha256:8b299c21c6d7f6fa77dda2a4b886d98e5be40052563b7d8814b469613870d74c"},{"path":"docs/release-readiness.md","sha256":"sha256:50fde18197710993f13ab039beff4f08173c035678472cd40396f10f3a22234c"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:b4ae0c7faa381e33adea95155c3c7e1d5eedf363bb5826735670aa299e8d10d0"},{"path":"docs/traceability.json","sha256":"sha256:467ff43c34e4ffbc3ab5c9d8bd88e13c0fd4da7cc8ef8ac9af8956c63c89700d"},{"path":"docs/release-readiness.md","sha256":"sha256:50fde18197710993f13ab039beff4f08173c035678472cd40396f10f3a22234c"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -473,6 +473,25 @@
       }
     },
     {
+      "id": "FEAT-014",
+      "title": "Restructure README and repository description around agent-consumable knowledge",
+      "issue": 67,
+      "specification_sections": [
+        "1",
+        "3",
+        "25"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "README.md"
+        ],
+        "tests": [
+          "tests/governance/governance.test.mjs"
+        ]
+      }
+    },
+    {
       "id": "REL-001",
       "title": "Prepare reviewed private-to-public MVP release",
       "issue": 10,

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -487,7 +487,7 @@
           "README.md"
         ],
         "tests": [
-          "tests/governance/governance.test.mjs"
+          "tests/governance/readme.test.mjs"
         ]
       }
     },

--- a/tests/governance/readme.test.mjs
+++ b/tests/governance/readme.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { access } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const readme = await readFile("README.md", "utf8");
+
+test("FEAT-014 README keeps the pre-release and review-everything posture", () => {
+  assert.ok(readme.includes("pre-release MVP development"), "pre-release notice must stay");
+  assert.ok(readme.includes("It is not a supported release."));
+  assert.ok(readme.includes("Generative AI can make mistakes"));
+});
+
+test("FEAT-014 every relative README link resolves to a repository path", async () => {
+  const links = [...readme.matchAll(/\]\(([^)#]+)(?:#[^)]*)?\)/gu)]
+    .map(([, target]) => target)
+    .filter((target) => !/^[a-z]+:/u.test(target));
+  assert.ok(links.length >= 15, "README must keep its repository links");
+  for (const target of links) await assert.doesNotReject(access(target), `README links to a missing path: ${target}`);
+});
+
+test("FEAT-014 the harness table names every generated distribution", () => {
+  for (const harness of ["claude-code", "codex", "kiro", "kiro-ide", "mcp"]) {
+    assert.ok(readme.includes(`distribution/${harness}`), `harness table must reference distribution/${harness}`);
+  }
+});


### PR DESCRIPTION
Closes #67
Stacked on #69 (FEAT-013).

- Requirement IDs: FEAT-014
- Specification sections: K-DLC §1, §3, §25

## Change
- README restructured along the one-core-many-harnesses model: what/why lead (turn documents into agent-consumable OKF knowledge), key features, pick-your-harness table (Claude Code, Codex, Kiro CLI/IDE, MCP), quick start, ADR-002 layout section, governance/status links preserved, pre-release and review-everything callouts retained.
- GitHub repository description already updated to match.

## Risk and rollback
Documentation-only; conformance posture unchanged (not-ready stated). Rollback: revert commit.

## Commands and results:

```text
Node v24.5.0
npm test -> PASS (223/223)
npm run check:governance -> PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)