### PR TITLE
fix: input-class errors and truthful harness instructions (#73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ projections — plain files remain the durable contract.
 | Harness | Install | Invoke |
 | --- | --- | --- |
 | **Claude Code** | `claude plugin install <repo>/distribution/claude-code` | `/kdlc:<operation>`, `kdlc:<role>` agents |
-| **Codex CLI** (≥ 0.145) | copy `distribution/codex/` conventions | `$kdlc` skill, `.codex/agents/<role>` |
-| **Kiro CLI** (≥ 2.6) | copy `distribution/kiro/.kiro/` into your project | `/kdlc-<operation>`, `.kiro/agents/<role>` |
-| **Kiro IDE** | copy `distribution/kiro-ide/.kiro/` into your project | `/kdlc-<operation>`, `.kiro/agents/<role>` |
+| **Codex CLI** (≥ 0.145) | run Codex from this checkout; surface in `distribution/codex/` | `$kdlc` skill, `.codex/agents/<role>` |
+| **Kiro CLI** (≥ 2.6) | run Kiro from this checkout; surface in `distribution/kiro/.kiro/` | `/kdlc-<operation>`, `.kiro/agents/<role>` |
+| **Kiro IDE** | run Kiro from this checkout; surface in `distribution/kiro-ide/.kiro/` | `/kdlc-<operation>`, `.kiro/agents/<role>` |
 | **Any MCP client** | `distribution/mcp/desktop.json` (stdio) / `custom-app.json` (HTTP) | `kb_search`, `kb_fetch`, `proposal_create`, … |
 
 Adapters differ only in packaging: stage requirements, security policy, state

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -16,5 +16,5 @@
   "pending_requirements": [
     {"id": "REL-001", "issue": 10, "reason": "Statistical evaluation, final artifact/version agreement, external protections, and independent release verification remain pending.", "release_blocking": true}
   ],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:b4ae0c7faa381e33adea95155c3c7e1d5eedf363bb5826735670aa299e8d10d0"},{"path":"docs/traceability.json","sha256":"sha256:3f4d10137d24ca28da18e63fdb81603cd81e5c18d37823c07744a560e72893aa"},{"path":"docs/release-readiness.md","sha256":"sha256:50fde18197710993f13ab039beff4f08173c035678472cd40396f10f3a22234c"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:b4ae0c7faa381e33adea95155c3c7e1d5eedf363bb5826735670aa299e8d10d0"},{"path":"docs/traceability.json","sha256":"sha256:85ef5794ab71aeff119481f64415f4aa37ce8eca2e28e8ec47d858ab037de17a"},{"path":"docs/release-readiness.md","sha256":"sha256:50fde18197710993f13ab039beff4f08173c035678472cd40396f10f3a22234c"}]
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,6 +48,11 @@ kdlc status
 kdlc doctor
 ```
 
+On a fresh workspace, `doctor` reports `healthy: true` with three expected
+warnings — `dependencies.lock`, `cache.integrity`, and
+`policies.compatibility` are `missing` until you mount a dependency knowledge
+base and resolve policies. They need no action for a single-base project.
+
 ## 3. Ingest a source
 
 ```bash
@@ -107,19 +112,25 @@ descriptors, not by prompt text.
 
 ## 6. Pick your harness
 
-| Harness | Install | Invoke |
+| Harness | Setup | Invoke |
 |---|---|---|
 | Claude Code | `claude plugin install <repo>/distribution/claude-code` | `/kdlc:<operation>` commands, `kdlc:<role>` agents |
-| Codex CLI (≥ 0.145) | copy `distribution/codex/` conventions into your Codex setup | `$kdlc` skill (`SKILL.md`), `.codex/agents/<role>` |
-| Kiro CLI (≥ 2.6) | copy `distribution/kiro/.kiro/` into your project | `/kdlc-<operation>` skills, `.kiro/agents/<role>` |
-| Kiro IDE | copy `distribution/kiro-ide/.kiro/` into your project | `/kdlc-<operation>` skills, `.kiro/agents/<role>` |
+| Codex CLI (≥ 0.145) | point Codex at this checkout; skills/agents in `distribution/codex/` | `$kdlc` skill (`SKILL.md`), `.codex/agents/<role>` |
+| Kiro CLI (≥ 2.6) | point Kiro at this checkout; skills/agents in `distribution/kiro/.kiro/` | `/kdlc-<operation>` skills, `.kiro/agents/<role>` |
+| Kiro IDE | point Kiro at this checkout; skills/agents in `distribution/kiro-ide/.kiro/` | `/kdlc-<operation>` skills, `.kiro/agents/<role>` |
 | Any MCP client | `distribution/mcp/desktop.json` (stdio) or `custom-app.json` (HTTP) | `kb_search`, `kb_fetch`, `proposal_create`, … |
 
 Every harness invokes the same governed CLI engine and returns the same
 versioned JSON envelope; adapters never change stage requirements, security
-policy, state transitions, or artifact contracts (§25). Kiro operations run
-`node distribution/<harness>/run.mjs` from this repository checkout, so keep
-the checkout available (or `npm link` and adjust the runner path).
+policy, state transitions, or artifact contracts (§25).
+
+IMPORTANT: the Codex and Kiro skill files invoke
+`node distribution/<harness>/run.mjs`, whose imports resolve relative to this
+repository. Run those harnesses with this checkout as the working directory
+(your knowledge project can live anywhere; pass its path in the operation
+arguments), or use the Claude Code plugin / MCP server, which carry their own
+location. Do not copy `.kiro/` alone into another project — the runner will
+not resolve. A self-contained packaged runner is tracked as a follow-up.
 
 ## 7. MCP server
 
@@ -132,7 +143,9 @@ unauthenticated project server.
 
 ## Command reference
 
-`init`, `adopt`, `ingest`, `query`, `review`, `publish`, `status`, `lint`,
-`refresh`, `trace`, `conflicts`, `gaps`, `migrate`, `doctor`,
-`reconcile-edits`, `jobs`, `proposal` — see `distribution/claude-code/COMMANDS.md`
-for the harness bindings.
+Argument-free: `init`, `status`, `doctor`, `lint`, `jobs`, `conflicts`,
+`gaps`, `refresh`, `reconcile-edits`. Require arguments: `adopt <source...>`,
+`ingest <source...>`, `query <question>`, `trace <kb://...>`,
+`review <proposal-id> <decision> <receipt-id>`,
+`publish <proposal-id> <receipt-id>`, `proposal <json>`, `migrate <json>`.
+See `distribution/claude-code/COMMANDS.md` for the harness bindings.

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -510,6 +510,25 @@
       }
     },
     {
+      "id": "REQ-UX-001",
+      "title": "Clean input errors for trace/migrate and truthful harness install instructions",
+      "issue": 73,
+      "specification_sections": [
+        "25"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "packages/cli/index.mjs",
+          "docs/getting-started.md",
+          "README.md"
+        ],
+        "tests": [
+          "tests/governance/getting-started.test.mjs"
+        ]
+      }
+    },
+    {
       "id": "REL-001",
       "title": "Prepare reviewed private-to-public MVP release",
       "issue": 10,

--- a/packages/cli/index.mjs
+++ b/packages/cli/index.mjs
@@ -752,7 +752,13 @@ export function parseCli(argv) {
     if (!input.question)
       throw inputError("query requires a non-empty question");
   }
-  if (operation === "trace") input.uri = positionals[0];
+  if (operation === "trace") {
+    if (!positionals[0]) throw inputError("trace requires a concept reference, for example: kdlc trace kb://<knowledge-base-id>/<concept-id>");
+    input.uri = positionals[0];
+  }
+  if (operation === "migrate" && !positionals[0]) {
+    throw inputError("migrate requires a JSON argument object, for example: kdlc migrate '{\"target\": ...}'");
+  }
   if (operation === "review") {
     [input.proposal_id, input.decision, input.receipt_id] = positionals;
   }

--- a/tests/governance/getting-started.test.mjs
+++ b/tests/governance/getting-started.test.mjs
@@ -61,10 +61,17 @@ test("FEAT-011 the getting-started walkthrough works exactly as documented", asy
   assert.equal(query.envelope.ok, true);
   assert.equal(query.envelope.result.status, "not_found");
 
+  // REQ-UX-001: argument-requiring commands fail with input-class errors, not internal leaks.
+  for (const bare of [["trace"], ["migrate"]]) {
+    const failed = await run(root, ...bare);
+    assert.equal(failed.code, 2, `${bare[0]} without arguments must exit input class`);
+    assert.equal(failed.envelope.error.code, "KDLC_INPUT_INVALID", `${bare[0]} must return KDLC_INPUT_INVALID`);
+  }
+
   // Documented command surface stays honest.
   const guide = await readFile(resolve(repository, "docs/getting-started.md"), "utf8");
   const { CLI_COMMANDS } = await import(`file://${resolve(repository, "packages/cli/index.mjs")}`);
-  for (const command of CLI_COMMANDS) assert.ok(guide.includes(`\`${command}\``), `guide must mention CLI command: ${command}`);
+  for (const command of CLI_COMMANDS) assert.ok(guide.includes(`\`${command}`), `guide must mention CLI command: ${command}`);
   const packageManifest = JSON.parse(await readFile(resolve(repository, "package.json"), "utf8"));
   assert.equal(packageManifest.bin.kdlc, "./packages/cli/bin.mjs", "npm link instruction requires the kdlc bin entry");
 });


### PR DESCRIPTION
Closes #73
Stacked on #72 (REQ-SEC-001).

- Requirement IDs: REQ-UX-001
- Specification sections: K-DLC §25

## Change
- Bare 'kdlc trace' and 'kdlc migrate' now return KDLC_INPUT_INVALID (exit class 2) with actionable messages instead of leaking KDLC_CANONICAL_INVALID / KDLC_INTERNAL.
- README + getting-started harness instructions corrected: Codex/Kiro run from this checkout (copy-into-project verifiably fails with MODULE_NOT_FOUND); packaged runner tracked separately.
- Getting-started explains the three expected fresh-workspace doctor warnings and splits the command reference into argument-free vs argument-requiring commands.
- Walkthrough test asserts the corrected error classes.

## Risk and rollback
Input validation added before engine dispatch; no behavior change for valid invocations. Rollback: revert commit.

## Commands and results:

```text
Node v24.5.0
node --test tests/governance/getting-started.test.mjs -> PASS
npm test -> PASS (227/227)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)