### PR TITLE
docs: scope FEAT-008 and disclose the §26 sensor gap (#74)

### DIFF
--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -16,5 +16,5 @@
   "pending_requirements": [
     {"id": "REL-001", "issue": 10, "reason": "Statistical evaluation, final artifact/version agreement, external protections, and independent release verification remain pending.", "release_blocking": true}
   ],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:b4ae0c7faa381e33adea95155c3c7e1d5eedf363bb5826735670aa299e8d10d0"},{"path":"docs/traceability.json","sha256":"sha256:06767e531a8206859d6314ea23d9ca227d815a93e76f8374e2359145e6e667ea"},{"path":"docs/release-readiness.md","sha256":"sha256:e52ad10cd2ed40b010f592cb018720ffe266d034949f7e904a7b3294b303734e"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:b4ae0c7faa381e33adea95155c3c7e1d5eedf363bb5826735670aa299e8d10d0"},{"path":"docs/traceability.json","sha256":"sha256:9a8bc3d29f73bab79fa866850dca996f8df07d1a74e3b8fd59b3b90af550151a"},{"path":"docs/release-readiness.md","sha256":"sha256:e52ad10cd2ed40b010f592cb018720ffe266d034949f7e904a7b3294b303734e"}]
 }

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -16,5 +16,5 @@
   "pending_requirements": [
     {"id": "REL-001", "issue": 10, "reason": "Statistical evaluation, final artifact/version agreement, external protections, and independent release verification remain pending.", "release_blocking": true}
   ],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:b4ae0c7faa381e33adea95155c3c7e1d5eedf363bb5826735670aa299e8d10d0"},{"path":"docs/traceability.json","sha256":"sha256:85ef5794ab71aeff119481f64415f4aa37ce8eca2e28e8ec47d858ab037de17a"},{"path":"docs/release-readiness.md","sha256":"sha256:50fde18197710993f13ab039beff4f08173c035678472cd40396f10f3a22234c"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:b4ae0c7faa381e33adea95155c3c7e1d5eedf363bb5826735670aa299e8d10d0"},{"path":"docs/traceability.json","sha256":"sha256:06767e531a8206859d6314ea23d9ca227d815a93e76f8374e2359145e6e667ea"},{"path":"docs/release-readiness.md","sha256":"sha256:e52ad10cd2ed40b010f592cb018720ffe266d034949f7e904a7b3294b303734e"}]
 }

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -28,6 +28,19 @@ nondisclosure.
 The statement preserves package version `0.0.0-private`, `private: true`, and a
 machine-readable `not-ready` release status.
 
+## Known conformance gaps disclosed before release
+
+- Specification §26 lists ~24 deterministic sensor categories. The sensor
+  runtime (determinism checks, severity, auditable waivers) and the seven
+  governance-gate sensors (§27.4–§27.7) are implemented and tested; the
+  remaining §26 sensor definitions (OKF conformance, link/alias/orphan/index
+  checks, claim-sidecar consistency, lock-file drift, and related lint
+  sensors) are not yet implemented. Tracked as FEAT-015 (issue #75); the
+  FEAT-008 traceability entry is scoped accordingly. `kdlc lint` currently
+  validates the project manifest only.
+- Codex and Kiro harness surfaces run from this repository checkout; a
+  self-contained packaged runner is future work (see issue #73 notes).
+
 ## Repository settings requiring final evidence or action
 
 These items require repository-owner evidence or administration before release.

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -543,6 +543,24 @@
       }
     },
     {
+      "id": "REQ-TRACE-001",
+      "title": "Correct FEAT-008 section 26 scope and disclose the sensor-definition gap",
+      "issue": 74,
+      "specification_sections": [
+        "26"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "docs/release-readiness.md",
+          "docs/traceability.json"
+        ],
+        "tests": [
+          "tests/governance/governance.test.mjs"
+        ]
+      }
+    },
+    {
       "id": "REL-001",
       "title": "Prepare reviewed private-to-public MVP release",
       "issue": 10,

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -317,10 +317,7 @@
       "title": "Built-in governance sensors and policy enforcement",
       "issue": 23,
       "specification_sections": [
-        "26",
-        "27.1",
-        "27.2",
-        "27.3",
+        "26 (sensor runtime and governance-gate sensors only; remaining definitions tracked by FEAT-015)",
         "27.4",
         "27.5",
         "27.6",
@@ -525,6 +522,23 @@
         ],
         "tests": [
           "tests/governance/getting-started.test.mjs"
+        ]
+      }
+    },
+    {
+      "id": "FEAT-015",
+      "title": "Implement the remaining section 26 core sensor definitions",
+      "issue": 75,
+      "specification_sections": [
+        "26"
+      ],
+      "status": "planned",
+      "evidence": {
+        "implementation": [
+          "packages/lifecycle/src/sensors.mjs"
+        ],
+        "tests": [
+          "tests/governance/lifecycle.test.mjs"
         ]
       }
     },


### PR DESCRIPTION
Closes #74
Stacked on #76 (REQ-UX-001).

- Requirement IDs: REQ-TRACE-001, FEAT-015
- Specification sections: K-DLC §26

## Change
- FEAT-008 traceability entry scoped honestly: sensor runtime + §27.4–27.7 governance-gate sensors; no longer claims full §26.
- FEAT-015 added as planned (issue #75) for the remaining §26 sensor definitions.
- docs/release-readiness.md gains a 'Known conformance gaps disclosed before release' section covering the sensor gap and the checkout-bound Codex/Kiro runners.
- Mechanical conformance evidence hash rebinds (traceability, release-readiness).

## Risk and rollback
Documentation honesty only; no behavior change. Rollback: revert commit.

## Commands and results:

```text
Node v24.5.0
npm run check:governance -> PASS (23 traceable requirements, 5 gates)
npm test -> PASS (227/227)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)