### PR TITLE
docs: pre-register REL-002 statistical capture requirement (#57)

### DIFF
--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -16,5 +16,5 @@
   "pending_requirements": [
     {"id": "REL-001", "issue": 10, "reason": "Statistical evaluation, final artifact/version agreement, external protections, and independent release verification remain pending.", "release_blocking": true}
   ],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:b4ae0c7faa381e33adea95155c3c7e1d5eedf363bb5826735670aa299e8d10d0"},{"path":"docs/traceability.json","sha256":"sha256:6513ad9893c6db3beefccd6b455486d68e8ac52dbf2cd9790b60e2822812b92c"},{"path":"docs/release-readiness.md","sha256":"sha256:9c46671ca5f40d9d484853d9551f1269d026bea900eb024d18c0f69526b45b81"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:b4ae0c7faa381e33adea95155c3c7e1d5eedf363bb5826735670aa299e8d10d0"},{"path":"docs/traceability.json","sha256":"sha256:610177696befd191b0832bd08563751e35d3fdde350c4036597be698e9326e9c"},{"path":"docs/release-readiness.md","sha256":"sha256:9c46671ca5f40d9d484853d9551f1269d026bea900eb024d18c0f69526b45b81"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -693,6 +693,23 @@
           "tests/governance/release-readiness.test.mjs"
         ]
       }
+    },
+    {
+      "id": "REL-002",
+      "title": "Freeze provider inputs and capture the 30-trial statistical release evaluation",
+      "issue": 57,
+      "specification_sections": [
+        "36"
+      ],
+      "status": "in-progress",
+      "evidence": {
+        "implementation": [
+          "docs/release-readiness.md"
+        ],
+        "tests": [
+          "tests/governance/statistical-release.test.mjs"
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Closes #57

Narrow traceability pre-registration (AGENTS.md rule 4) so the REL-002 contract and implementation PRs can validate; mirrors the FEAT-010 (#63) and REQ-EVAL-001 precedents. No production, evidence, or protected bytes change beyond the mechanical traceability hash rebind.

- Requirement IDs: REL-002
- Specification sections: K-DLC §36

Risk and rollback: documentation-only; revert to roll back.

## Commands and results:

```text
Node v24.5.0
npm run check:governance -> PASS (27 traceable requirements, 5 gates)
npm run check:release-evidence -> PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
