### PR TITLE
docs: amend the FEAT-019 eml contract to the hardened head (#88) [FEAT-019]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,6 +341,17 @@ or high finding must be attached. This authority is consumed and expires
 immediately when PR #89 merges or is closed, and it does not authorize any
 later protected change.
 
+Amendment (one-time, same authority): the PR #89 bypass above applies at
+exact head `0119f57a986c5e84e7f4bd07dad598f562735cf5`, which relative to the
+previously bound merged head `4f05bd70b56b60d271b91e2f2b8e3e8fe01bc2f9`
+additionally contains only the CodeQL-driven text/html sanitization
+hardening in `packages/normalizers/src/normalize.mjs` (whitespace/attribute-
+tolerant script/style close-tag matching; `&amp;` resolved last to prevent
+entity double-decoding) and its regression coverage in
+`tests/governance/eml-normalizer.test.mjs`. The protected schema transition
+pair, the 8-path confinement, and every other term above are unchanged and
+remain binding.
+
 ## Scope and safety
 
 - Preserve user changes and do not perform destructive Git operations.


### PR DESCRIPTION
Closes #88

## Traceability

- Requirement IDs: FEAT-019
- Specification sections: §9.2

## Summary

AGENTS-only amendment to the PR #90 contract: CodeQL (correctly) flagged two defects in the eml normalizer's HTML stripping at the previously bound head — `</script >` escaping the block filter (js/bad-tag-filter) and `&amp;` unescaped before `&lt;` enabling double-decoding (js/double-escaping). The fix plus regression tests moved PR #89's head to `0119f57`, outside the previously permitted delta. This amendment rebinds the same authority to that exact head; the protected schema hash pair, 8-path confinement, and all other terms are unchanged.

## Verification

Commands and results:

```text
npm test at 0119f57 -> 252 tests, 252 pass, 0 fail
git diff 4f05bd7..0119f57 --name-only -> packages/normalizers/src/normalize.mjs, tests/governance/eml-normalizer.test.mjs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
