### PR TITLE
docs: authorize the FEAT-020 msg release-schema transition (#92) [FEAT-020]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,6 +352,46 @@ entity double-decoding) and its regression coverage in
 pair, the 8-path confinement, and every other term above are unchanged and
 remain binding.
 
+PR #93, linked to issue #92, may use a one-time protected release-schema
+bypass for the Outlook msg normalizer. The authorized pre-contract head is
+`2f0edd44131cf6120138f0c318875cde42d2f143` on pre-contract base
+`041b7fef410a903bf80939fb12e0b1601130a98e`. It authorizes exactly one
+protected transition:
+`core/schemas/release/conformance-statement.schema.json` from SHA-256
+`f08e18d3a824b2112f4a50781181b77f9b769056ee676da8c1ea632d10432158`
+to SHA-256
+`7846b5dc04f1d6297a6a8db34835a54605794fd8d402661cd48d603eeede0ee1`,
+whose complete byte difference is the insertion of the single enum value
+`"msg"` into the `format_profiles` items list.
+
+After this AGENTS-only contract (which also pre-registers FEAT-020 as
+planned and mechanically rebinds the traceability evidence hash) merges,
+PR #93 may target only the descendant base produced by merging main into
+the pre-contract head. The permitted delta beyond that mechanical merge is
+limited to: flipping the FEAT-020 traceability status from planned to
+implemented and filling its evidence arrays; the mechanical traceability
+evidence-hash rebind in `distribution/release/conformance-statement.json`;
+and, if a required security scanner raises findings on the pre-contract
+head, minimal fixes confined to `packages/normalizers/src/normalize.mjs`
+and `tests/governance/msg-normalizer.test.mjs` that must be enumerated in
+the owner exception record and covered by the attached independent review.
+The protected schema byte transition must remain exactly the pair above.
+The complete PR #93 content diff against its base is limited to 7 paths:
+that schema transition; `packages/normalizers/src/descriptors.mjs`;
+`packages/normalizers/src/normalize.mjs`; the derived entries in
+`distribution/conformance.json` and
+`distribution/release/conformance-statement.json`; the FEAT-020 entry in
+`docs/traceability.json`; and the new
+`tests/governance/msg-normalizer.test.mjs`. No workflow, validator, scorer,
+statistical, release-status, or other schema byte may change. Candidate
+tests and every non-self required or security check must pass; the owner
+exception record must identify the Repository policy protected
+self-difference on that single schema as its sole failed check and bypass
+reason. An independent read-only agent review of the exact merged head with
+no unresolved critical or high finding must be attached. This authority is
+consumed and expires immediately when PR #93 merges or is closed, and it
+does not authorize any later protected change.
+
 ## Scope and safety
 
 - Preserve user changes and do not perform destructive Git operations.

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -14,5 +14,5 @@
   "tools": ["project_init", "project_get", "project_list_mounts", "kb_search", "kb_fetch", "kb_trace", "kb_conflicts", "kb_gaps", "source_excerpt", "job_status", "ingest_start", "proposal_create", "review_submit", "publish_request", "job_cancel"],
   "transports": ["stdio", "streamable-http"],
   "pending_requirements": [],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:a38836b9b22564ac2507dfde17ee311ca08d521a39b298816d12823ced7364db"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:47d06521497860a46059750e254e086730c773f3d44077dd11d40412ea63b00d"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -797,6 +797,20 @@
           "tests/governance/eml-normalizer.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-020",
+      "title": "Outlook .msg normalizer (CFBF/MAPI) with attachment inventory",
+      "issue": 92,
+      "specification_sections": [
+        "5.7",
+        "9.2"
+      ],
+      "status": "planned",
+      "evidence": {
+        "implementation": [],
+        "tests": []
+      }
     }
   ]
 }


### PR DESCRIPTION
Closes #92

## Traceability

- Requirement IDs: FEAT-020
- Specification sections: §9.2

## Summary

AGENTS-only contract (precedent: #90/#91 for FEAT-019) authorizing implementation PR #93 at pre-contract head `2f0edd4` on base `041b7fe` to add `"msg"` to the protected conformance-statement schema enum (`f08e18d3…` → `7846b5dc…`, one line). Pre-registers FEAT-020 as planned with the mechanical traceability rebind, carries descendant-base language for the post-contract merge, and — learning from FEAT-019 — pre-authorizes minimal security-scanner fixes confined to the parser and its tests, provided they are enumerated in the owner exception record and covered by the independent review. Authority consumed when PR #93 merges or closes.

## Verification

Commands and results:

```text
npm test on the bound implementation head 2f0edd4 -> 257 tests, 257 pass, 0 fail
shasum -a 256 core/schemas/release/conformance-statement.schema.json (head) -> 7846b5dc04f1d6297a6a8db34835a54605794fd8d402661cd48d603eeede0ee1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
