### PR TITLE
docs: authorize the FEAT-022 html release-schema transition (#96) [FEAT-022]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -392,6 +392,47 @@ no unresolved critical or high finding must be attached. This authority is
 consumed and expires immediately when PR #93 merges or is closed, and it
 does not authorize any later protected change.
 
+PR #100, linked to issue #96, may use a one-time protected release-schema
+bypass for the HTML normalizer. The authorized pre-contract head is
+`1d10c0f10f2d608b3e331c4f38b5f45b472ceff1` on pre-contract base
+`419f7052d4986c0f267b558276b9513467379b2d`. It authorizes exactly one
+protected transition:
+`core/schemas/release/conformance-statement.schema.json` from SHA-256
+`7846b5dc04f1d6297a6a8db34835a54605794fd8d402661cd48d603eeede0ee1`
+to SHA-256
+`bc0607c136e5aeace73fb4c8891cc5d43c3dce85aea5bd40562fca465db9f9c9`,
+whose complete byte difference is the insertion of the single enum value
+`"html"` into the `format_profiles` items list.
+
+After this AGENTS-only contract (which also pre-registers FEAT-022 as
+planned and mechanically rebinds the traceability evidence hash) merges,
+PR #100 may target only the descendant base produced by merging main into
+the pre-contract head. The permitted delta beyond that mechanical merge is
+limited to: flipping the FEAT-022 traceability status from planned to
+implemented and filling its evidence arrays; the mechanical traceability
+evidence-hash rebind in `distribution/release/conformance-statement.json`;
+and, if a required security scanner raises findings on the pre-contract
+head, minimal fixes confined to `packages/normalizers/src/normalize.mjs`
+and `tests/governance/html-normalizer.test.mjs` that must be enumerated in
+the owner exception record and covered by the attached independent review.
+The protected schema byte transition must remain exactly the pair above.
+The complete PR #100 content diff against its base is limited to 8 paths:
+that schema transition; `packages/normalizers/src/descriptors.mjs`;
+`packages/normalizers/src/normalize.mjs`; the two new locator kinds' host
+schema `core/schemas/normalization/normalized-unit.schema.json`; the derived
+entries in `distribution/conformance.json` and
+`distribution/release/conformance-statement.json`; the FEAT-022 entry in
+`docs/traceability.json`; and the new
+`tests/governance/html-normalizer.test.mjs`. No workflow, validator,
+scorer, statistical, release-status, or other schema byte may change.
+Candidate tests and every non-self required or security check must pass;
+the owner exception record must identify the Repository policy protected
+self-difference on that single schema as its sole failed check and bypass
+reason. An independent read-only agent review of the exact merged head with
+no unresolved critical or high finding must be attached. This authority is
+consumed and expires immediately when PR #100 merges or is closed, and it
+does not authorize any later protected change.
+
 ## Scope and safety
 
 - Preserve user changes and do not perform destructive Git operations.

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -14,5 +14,5 @@
   "tools": ["project_init", "project_get", "project_list_mounts", "kb_search", "kb_fetch", "kb_trace", "kb_conflicts", "kb_gaps", "source_excerpt", "job_status", "ingest_start", "proposal_create", "review_submit", "publish_request", "job_cancel"],
   "transports": ["stdio", "streamable-http"],
   "pending_requirements": [],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:feee441d5e2250739b30e8b22e4bf000ab3789896dcda419625e6f47f9fb3754"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:ae5f5f934359274d5640b3699a739cacf9c7da46c7bf671aff53b07005504043"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -838,6 +838,20 @@
           "tests/governance/remote-sources.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-022",
+      "title": "HTML normalizer with DOM-path locators",
+      "issue": 96,
+      "specification_sections": [
+        "5.7",
+        "9.2"
+      ],
+      "status": "planned",
+      "evidence": {
+        "implementation": [],
+        "tests": []
+      }
     }
   ]
 }


### PR DESCRIPTION
Closes #96

## Traceability

- Requirement IDs: FEAT-022
- Specification sections: §9.2

## Summary

AGENTS-only contract (precedent: #90/#91, #94) authorizing implementation PR #100 at pre-contract head `1d10c0f` on base `419f705` to add `"html"` to the protected conformance-statement schema enum (`7846b5dc…` → `bc0607c1…`, one line). Pre-registers FEAT-022 as planned with the mechanical traceability rebind, carries descendant-base language, and pre-authorizes minimal scanner-driven fixes confined to the parser and its tests. Authority consumed when PR #100 merges or closes.

## Verification

Commands and results:

```text
npm test on the bound implementation head 1d10c0f -> 266 tests, 266 pass, 0 fail
shasum -a 256 core/schemas/release/conformance-statement.schema.json (head) -> bc0607c136e5aeace73fb4c8891cc5d43c3dce85aea5bd40562fca465db9f9c9
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
