### PR TITLE
docs: amend the FEAT-022 html contract to the hardened head (#96) [FEAT-022]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -433,6 +433,18 @@ no unresolved critical or high finding must be attached. This authority is
 consumed and expires immediately when PR #100 merges or is closed, and it
 does not authorize any later protected change.
 
+Amendment (one-time, same authority): the PR #100 bypass above applies at
+exact head `b46f456e981d6d5bdf822ce3d07906b18a5696a8`, which relative to the
+previously bound merged head `210e0d2fd159b4d9857fb59267e6aeb3c50cbb42`
+additionally contains only the independent-review-driven fixes in
+`packages/normalizers/src/normalize.mjs` (table cells decode entities
+exactly once, preserving the single-pass invariant; the active-link scheme
+filter judges the entity-decoded, control-stripped target, with `colon`,
+`sol`, `tab`, and `newline` added to the entity map) and their regression
+coverage in `tests/governance/html-normalizer.test.mjs`. The protected
+schema transition pair, the 8-path confinement, and every other term above
+are unchanged and remain binding.
+
 ## Scope and safety
 
 - Preserve user changes and do not perform destructive Git operations.


### PR DESCRIPTION
Closes #96

## Traceability

- Requirement IDs: FEAT-022
- Specification sections: §9.2

## Summary

AGENTS-only amendment (precedent #91): the independent review of PR #100 found two MEDIUM defects — table cells double-decoding entities (breaking the single-pass invariant) and the active-link filter bypassable via tab/entity obfuscation (`java\tscript:`, `&#106;avascript:`, `&colon;`). Fixed with regression tests at head `b46f456`; this rebinds the same authority to that exact head. The protected schema hash pair and all other terms are unchanged.

## Verification

Commands and results:

```text
npm test at b46f456 -> 267 tests, 267 pass, 0 fail
git diff 210e0d2..b46f456 --name-only -> packages/normalizers/src/normalize.mjs, tests/governance/html-normalizer.test.mjs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
