### PR TITLE
feat: Google Drive source connector with native-format export (#98) [FEAT-024]

### DIFF
--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -14,5 +14,5 @@
   "tools": ["project_init", "project_get", "project_list_mounts", "kb_search", "kb_fetch", "kb_trace", "kb_conflicts", "kb_gaps", "source_excerpt", "job_status", "ingest_start", "proposal_create", "review_submit", "publish_request", "job_cancel"],
   "transports": ["stdio", "streamable-http"],
   "pending_requirements": [],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:14b374a027c5a9a668e0289da054af49fc82dd6f77ca3bcf79823bf4d2c2a646"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:2bbb495c4f5339dde375aaa859d113f463876331c1347cedc1e47ef5fd87a335"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -881,6 +881,26 @@
           "tests/governance/source-connectors.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-024",
+      "title": "Google Drive source connector with native-format export",
+      "issue": 98,
+      "specification_sections": [
+        "5.7",
+        "7",
+        "9.2"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "packages/connectors/google-drive.mjs",
+          "packages/connectors/index.mjs"
+        ],
+        "tests": [
+          "tests/governance/gdrive-connector.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/packages/connectors/google-drive.mjs
+++ b/packages/connectors/google-drive.mjs
@@ -1,0 +1,105 @@
+// Google Drive source connector (FEAT-024, #98). Binary files download as
+// original bytes; native Google formats (Docs/Sheets/Slides/Drawings) export
+// to OOXML/PDF so the existing normalizers apply, with the export choice
+// recorded as fidelity metadata on the descriptor. Injected transport owns
+// authentication (drive.readonly); revision IDs are the staleness identity.
+
+import { byteHash } from "../core/index.mjs";
+import { ConnectorError, expectBytes, expectJson, instant } from "./transport.mjs";
+
+const DRIVE = "https://www.googleapis.com/drive/v3";
+const FIELDS = "id,name,mimeType,headRevisionId,version,trashed,shared,capabilities/canDownload,exportLinks";
+
+/** Native Google formats and the export the pipeline can normalize. */
+export const DRIVE_EXPORTS = Object.freeze({
+  "application/vnd.google-apps.document": { mime: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", extension: ".docx" },
+  "application/vnd.google-apps.spreadsheet": { mime: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", extension: ".xlsx" },
+  "application/vnd.google-apps.presentation": { mime: "application/vnd.openxmlformats-officedocument.presentationml.presentation", extension: ".pptx" },
+  "application/vnd.google-apps.drawing": { mime: "application/pdf", extension: ".pdf" },
+});
+
+function revisionOf(file) {
+  if (typeof file.headRevisionId === "string" && file.headRevisionId.length > 0) return { kind: "revision-id", value: file.headRevisionId };
+  // Native Google formats expose no headRevisionId; the monotonic version
+  // counter is the documented change signal for them.
+  if (file.version !== undefined && String(file.version).length > 0) return { kind: "revision-id", value: `version:${file.version}` };
+  return null;
+}
+
+export class GoogleDriveConnector {
+  constructor(transport) {
+    this.transport = transport;
+  }
+
+  async #metadata(fileId) {
+    return expectJson(await this.transport.request({ method: "GET", url: `${DRIVE}/files/${encodeURIComponent(fileId)}?supportsAllDrives=true&fields=${encodeURIComponent(FIELDS)}` }), "Drive file metadata");
+  }
+
+  /**
+   * Fetch a file's bytes plus its FEAT-021 descriptor. Binary content
+   * downloads as-is; native Google formats export per DRIVE_EXPORTS with the
+   * choice recorded in export_fidelity.
+   */
+  async fetchFile({ fileId, acquiredAt = instant() }) {
+    const file = await this.#metadata(fileId);
+    if (file.trashed) throw new ConnectorError(`Drive file ${fileId} is in the trash — restore it or drop the source`);
+    if (file.capabilities && file.capabilities.canDownload === false) {
+      throw new ConnectorError(`Drive file ${fileId} cannot be downloaded with this credential (view-only restriction)`);
+    }
+    const revision = revisionOf(file);
+    if (!revision) throw new ConnectorError(`Drive file ${fileId} carries no usable revision identity`);
+    const nativeExport = DRIVE_EXPORTS[file.mimeType] ?? null;
+    let bytes; let mediaType; let filename; let exportFidelity;
+    if (nativeExport) {
+      bytes = expectBytes(await this.transport.request({ method: "GET", url: `${DRIVE}/files/${encodeURIComponent(fileId)}/export?mimeType=${encodeURIComponent(nativeExport.mime)}` }), "Drive export");
+      mediaType = nativeExport.mime;
+      filename = `${file.name ?? fileId}${nativeExport.extension}`;
+      exportFidelity = `exported from ${file.mimeType} — comments, suggestions, and revision history are not carried`;
+    } else if ((file.mimeType ?? "").startsWith("application/vnd.google-apps.")) {
+      throw new ConnectorError(`Drive file ${fileId} is a ${file.mimeType} — this native format has no supported export`);
+    } else {
+      bytes = expectBytes(await this.transport.request({ method: "GET", url: `${DRIVE}/files/${encodeURIComponent(fileId)}?alt=media&supportsAllDrives=true` }), "Drive download");
+      mediaType = file.mimeType ?? "";
+      filename = file.name ?? `${fileId}`;
+      exportFidelity = null;
+    }
+    return {
+      bytes,
+      filename,
+      mediaType,
+      ...(exportFidelity ? { export_fidelity: exportFidelity } : {}),
+      descriptor: {
+        provider: "google-drive",
+        remote_id: fileId,
+        revision,
+        acquired_via: "connector",
+        acquired_at: acquiredAt,
+        content_hash: byteHash(bytes),
+        access_context: file.shared
+          ? { visibility: "internal", detail: "shared in Google Drive — audience follows the file's sharing settings" }
+          : { visibility: "restricted", detail: "not shared beyond its owner" },
+        display_name: file.name ?? undefined,
+      },
+    };
+  }
+
+  /** Cheap staleness probe; null means deleted, trashed, or access lost. */
+  async probe(receipt) {
+    try {
+      const file = await this.#metadata(receipt.remote_id);
+      if (file.trashed) return null;
+      const revision = revisionOf(file);
+      return revision ?? null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+export const GOOGLE_DRIVE_CAPABILITIES = Object.freeze({
+  providers: ["google-drive"],
+  operations: ["fetchFile", "probe"],
+  scopes_required: ["https://www.googleapis.com/auth/drive.readonly"],
+  writes: false,
+  deferrals: ["folder crawl", "comments", "revision-history diffs", "forms and sites native formats"],
+});

--- a/packages/connectors/index.mjs
+++ b/packages/connectors/index.mjs
@@ -5,4 +5,5 @@
 
 export { GraphConnector, GRAPH_CAPABILITIES } from "./graph.mjs";
 export { ConfluenceConnector, CONFLUENCE_CAPABILITIES } from "./confluence.mjs";
+export { GoogleDriveConnector, GOOGLE_DRIVE_CAPABILITIES, DRIVE_EXPORTS } from "./google-drive.mjs";
 export { ConnectorError, assessReceipts, expectBytes, expectJson, instant } from "./transport.mjs";

--- a/security/npm-package-files.json
+++ b/security/npm-package-files.json
@@ -293,6 +293,7 @@
     "packages/cli/index.mjs",
     "packages/cli/setup.mjs",
     "packages/connectors/confluence.mjs",
+    "packages/connectors/google-drive.mjs",
     "packages/connectors/graph.mjs",
     "packages/connectors/index.mjs",
     "packages/connectors/transport.mjs",

--- a/tests/governance/gdrive-connector.test.mjs
+++ b/tests/governance/gdrive-connector.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { zipSync, strToU8 } from "fflate";
+import test from "node:test";
+
+import { byteHash } from "../../packages/core/index.mjs";
+import { DRIVE_EXPORTS, GOOGLE_DRIVE_CAPABILITIES, GoogleDriveConnector } from "../../packages/connectors/index.mjs";
+import { bindReceipt, receiptStaleness, validateRemoteDescriptor } from "../../packages/sources/index.mjs";
+import { normalize } from "../../packages/normalizers/index.mjs";
+
+function recorded(routes) {
+  return { request: async ({ url }) => routes[url] ?? { status: 404 } };
+}
+
+const DRIVE = "https://www.googleapis.com/drive/v3";
+const FIELDS = encodeURIComponent("id,name,mimeType,headRevisionId,version,trashed,shared,capabilities/canDownload,exportLinks");
+const meta = (fileId) => `${DRIVE}/files/${fileId}?supportsAllDrives=true&fields=${FIELDS}`;
+
+// A minimal real .docx so the exported bytes flow through the true normalizer.
+const docxBytes = zipSync({
+  "[Content_Types].xml": strToU8("<Types><Override PartName='/word/document.xml' ContentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'/></Types>"),
+  "_rels/.rels": strToU8("<Relationships><Relationship Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships>"),
+  "word/document.xml": strToU8("<w:document xmlns:w='w'><w:body><w:p><w:r><w:t>Exported design note</w:t></w:r></w:p></w:body></w:document>")
+});
+const mdBytes = new TextEncoder().encode("# Note\n\nPlain binary download.\n");
+
+test("FEAT-024: native Google Docs export to docx with fidelity metadata and version-counter revisions", async () => {
+  const routes = {
+    [meta("doc1")]: { status: 200, json: () => ({ id: "doc1", name: "Design Note", mimeType: "application/vnd.google-apps.document", version: "41", shared: true }) },
+    [`${DRIVE}/files/doc1/export?mimeType=${encodeURIComponent(DRIVE_EXPORTS["application/vnd.google-apps.document"].mime)}`]: { status: 200, bytes: () => docxBytes }
+  };
+  const connector = new GoogleDriveConnector(recorded(routes));
+  const fetched = await connector.fetchFile({ fileId: "doc1", acquiredAt: "2026-08-16T12:00:00Z" });
+  assert.deepEqual(validateRemoteDescriptor(fetched.descriptor), []);
+  assert.deepEqual(fetched.descriptor.revision, { kind: "revision-id", value: "version:41" });
+  assert.equal(fetched.filename, "Design Note.docx");
+  assert.match(fetched.export_fidelity, /comments, suggestions, and revision history are not carried/);
+  assert.equal(fetched.descriptor.access_context.visibility, "internal");
+  const result = await normalize({ bytes: Buffer.from(fetched.bytes), filename: fetched.filename });
+  assert.equal(result.manifest.format, "docx");
+  assert.ok(result.units.some(({ text }) => text === "Exported design note"));
+});
+
+test("FEAT-024: binary files download as original bytes with headRevisionId", async () => {
+  const routes = {
+    [meta("f2")]: { status: 200, json: () => ({ id: "f2", name: "note.md", mimeType: "text/markdown", headRevisionId: "0B-rev-77" }) },
+    [`${DRIVE}/files/f2?alt=media&supportsAllDrives=true`]: { status: 200, bytes: () => mdBytes }
+  };
+  const fetched = await new GoogleDriveConnector(recorded(routes)).fetchFile({ fileId: "f2", acquiredAt: "2026-08-16T12:00:00Z" });
+  assert.deepEqual(fetched.descriptor.revision, { kind: "revision-id", value: "0B-rev-77" });
+  assert.equal(fetched.descriptor.access_context.visibility, "restricted");
+  assert.equal(fetched.export_fidelity, undefined);
+  const receipt = bindReceipt(fetched.descriptor, fetched.bytes, { sourceId: "src_00000000000000f2", receivedAt: "2026-08-16T12:00:01Z" });
+  assert.equal(receipt.content_hash, byteHash(mdBytes));
+  assert.equal((await normalize({ bytes: Buffer.from(fetched.bytes), filename: fetched.filename })).manifest.format, "markdown");
+});
+
+test("FEAT-024: trashed, view-only, unexportable, and denied files fail closed with plain reasons", async () => {
+  const cases = {
+    trash: { status: 200, json: () => ({ id: "trash", trashed: true, mimeType: "text/plain" }) },
+    locked: { status: 200, json: () => ({ id: "locked", mimeType: "application/pdf", headRevisionId: "r", capabilities: { canDownload: false } }) },
+    form: { status: 200, json: () => ({ id: "form", mimeType: "application/vnd.google-apps.form", version: "3" }) },
+    norev: { status: 200, json: () => ({ id: "norev", mimeType: "text/plain" }) }
+  };
+  const routes = Object.fromEntries(Object.entries(cases).map(([fileId, response]) => [meta(fileId), response]));
+  const connector = new GoogleDriveConnector(recorded(routes));
+  await assert.rejects(connector.fetchFile({ fileId: "trash" }), /in the trash/);
+  await assert.rejects(connector.fetchFile({ fileId: "locked" }), /view-only restriction/);
+  await assert.rejects(connector.fetchFile({ fileId: "form" }), /no supported export/);
+  await assert.rejects(connector.fetchFile({ fileId: "norev" }), /no usable revision identity/);
+  await assert.rejects(connector.fetchFile({ fileId: "missing" }), /not found/);
+});
+
+test("FEAT-024: probe feeds staleness — changed version, trashed, and permission-lost paths", async () => {
+  const routes = {
+    [meta("doc1")]: { status: 200, json: () => ({ id: "doc1", name: "Design Note", mimeType: "application/vnd.google-apps.document", version: "44" }) },
+    [meta("gonedoc")]: { status: 200, json: () => ({ id: "gonedoc", trashed: true, mimeType: "text/plain" }) }
+  };
+  const connector = new GoogleDriveConnector(recorded(routes));
+  const receipt = bindReceipt(
+    { provider: "google-drive", remote_id: "doc1", revision: { kind: "revision-id", value: "version:41" }, acquired_via: "connector", acquired_at: "2026-08-16T12:00:00Z", content_hash: byteHash(docxBytes), access_context: { visibility: "internal" } },
+    docxBytes, { sourceId: "src_0000000000000d01", receivedAt: "2026-08-16T12:00:01Z" }
+  );
+  const live = await connector.probe(receipt);
+  const verdict = receiptStaleness(receipt, live);
+  assert.equal(verdict.state, "stale");
+  assert.match(verdict.reason, /version:41 → version:44/);
+  assert.equal(await connector.probe({ ...receipt, remote_id: "gonedoc" }), null);
+  assert.equal(await connector.probe({ ...receipt, remote_id: "vanished" }), null);
+});
+
+test("FEAT-024: capabilities are read-only with honest deferrals; no credentials in outputs", async () => {
+  assert.equal(GOOGLE_DRIVE_CAPABILITIES.writes, false);
+  assert.deepEqual(GOOGLE_DRIVE_CAPABILITIES.scopes_required, ["https://www.googleapis.com/auth/drive.readonly"]);
+  assert.ok(GOOGLE_DRIVE_CAPABILITIES.deferrals.includes("folder crawl"));
+  const routes = {
+    [meta("f2")]: { status: 200, json: () => ({ id: "f2", name: "note.md", mimeType: "text/markdown", headRevisionId: "r1" }) },
+    [`${DRIVE}/files/f2?alt=media&supportsAllDrives=true`]: { status: 200, bytes: () => mdBytes }
+  };
+  const fetched = await new GoogleDriveConnector(recorded(routes)).fetchFile({ fileId: "f2" });
+  assert.ok(!/authorization|bearer|token|secret/i.test(JSON.stringify(fetched.descriptor)));
+});


### PR DESCRIPTION
Closes #98

## Traceability

- Requirement IDs: FEAT-024
- Specification sections: §5.7, §7, §9.2

## Summary

Final phase of remote source support — Google Drive over the same injected-transport contract:

- **Binary files** download as original bytes with `headRevisionId` revisions; **native Google formats** (Docs/Sheets/Slides/Drawings) export to docx/xlsx/pptx/pdf so the existing normalizers apply, with the export choice recorded as fidelity metadata ("comments, suggestions, and revision history are not carried") and the monotonic `version` counter as the revision identity (native formats expose no headRevisionId).
- **Fail-closed** with plain reasons: trashed files, view-only download restrictions, native formats without a supported export (Forms/Sites), missing revision identities, 403/404/429.
- **Probe** feeds `receiptStaleness`/`assessReceipts` — changed version → stale with the delta in the reason; trashed/vanished/permission-lost → unreachable → investigate proposal.
- Read-only scope (`drive.readonly`), recorded fixtures only, credential-blindness test-asserted; end-to-end coverage runs an exported real .docx and a binary markdown download through the true normalizer pipeline. Shared drives supported via `supportsAllDrives`.

Supply chain: +1 packaged file (356 exact paths). No protected files; pinned suites untouched.

## Verification

Commands and results:

```
$ npm test
tests 278 / pass 278 / fail 0   (new tests/governance/gdrive-connector.test.mjs)

$ node packages/adapters/generate.mjs --check
(no output — no drift)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
