### PR TITLE
feat: Claude Code marketplace manifest and install fix (#112) [FEAT-028]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,12 @@
+{
+  "name": "kdlc",
+  "owner": { "name": "AIThinkers", "url": "https://github.com/aithinkers" },
+  "plugins": [
+    {
+      "name": "kdlc",
+      "source": "./distribution/claude-code",
+      "description": "Governed K-DLC knowledge lifecycle: /kdlc:* commands, role agents, session hooks, and plain-language guides.",
+      "version": "0.2.0"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ kdlc setup <claude-code|codex|kiro|kiro-ide|mcp>[,...] <project-directory>
 
 | Harness | Setup | Invoke |
 | --- | --- | --- |
-| **Claude Code** | `kdlc setup claude-code .` prints the `claude plugin install …/distribution/claude-code` command | `/kdlc:<operation>`, `kdlc:<role>` agents |
+| **Claude Code** | `kdlc setup claude-code .` prints the marketplace add + `claude plugin install kdlc@kdlc` commands | `/kdlc:<operation>`, `kdlc:<role>` agents |
 | **Codex CLI** (≥ 0.145) | `kdlc setup codex <project>` writes `.codex/` (skill + agents) into your project; surface source in `distribution/codex/` | `$kdlc` skill, `.codex/agents/<role>` |
 | **Kiro CLI** (≥ 2.6) | `kdlc setup kiro <project>` writes `.kiro/` (skills + agents) into your project; surface source in `distribution/kiro/.kiro/` | `/kdlc-<operation>`, `.kiro/agents/<role>` |
 | **Kiro IDE** | `kdlc setup kiro-ide <project>`; surface source in `distribution/kiro-ide/.kiro/` | `/kdlc-<operation>`, `.kiro/agents/<role>` |

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -14,5 +14,5 @@
   "tools": ["project_init", "project_get", "project_list_mounts", "kb_search", "kb_fetch", "kb_trace", "kb_conflicts", "kb_gaps", "source_excerpt", "job_status", "ingest_start", "proposal_create", "review_submit", "publish_request", "job_cancel"],
   "transports": ["stdio", "streamable-http"],
   "pending_requirements": [],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:5f7a4b81c5260654f91f12f7fcab8572e3eb862921144e113fe2bbdb3417dd7f"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:32a76b61f34c0bc2b72b6cbbd5510c8b01e8e6be5ef60db09756fbc05c73d400"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -100,7 +100,8 @@ are detected by `kdlc lint` and reconciled with `kdlc reconcile-edits`.
 The generated plugin lives at `distribution/claude-code/`:
 
 ```bash
-claude plugin install <repo>/distribution/claude-code
+claude plugin marketplace add <repo>
+claude plugin install kdlc@kdlc
 ```
 
 It exposes the `/kdlc:<operation>` commands listed in
@@ -122,7 +123,7 @@ kdlc setup kiro ~/my-project        # or: claude-code | codex | kiro-ide | mcp (
 
 | Harness | Setup | Invoke |
 |---|---|---|
-| Claude Code | `kdlc setup claude-code .` prints the `claude plugin install …/distribution/claude-code` command | `/kdlc:<operation>` commands, `kdlc:<role>` agents |
+| Claude Code | `kdlc setup claude-code .` prints the marketplace add + `claude plugin install kdlc@kdlc` commands | `/kdlc:<operation>` commands, `kdlc:<role>` agents |
 | Codex CLI (≥ 0.145) | `kdlc setup codex <project>` writes `.codex/` (skill + agents); source in `distribution/codex/` | `$kdlc` skill (`SKILL.md`), `.codex/agents/<role>` |
 | Kiro CLI (≥ 2.6) | `kdlc setup kiro <project>` writes `.kiro/` (skills + agents); source in `distribution/kiro/.kiro/` | `/kdlc-<operation>` skills, `.kiro/agents/<role>` |
 | Kiro IDE | `kdlc setup kiro-ide <project>`; source in `distribution/kiro-ide/.kiro/` | `/kdlc-<operation>` skills, `.kiro/agents/<role>` |

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -962,6 +962,27 @@
           "tests/governance/readme.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-028",
+      "title": "Claude Code marketplace manifest and two-step plugin install",
+      "issue": 112,
+      "specification_sections": [
+        "9.2",
+        "25"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          ".claude-plugin/marketplace.json",
+          "packages/cli/setup.mjs",
+          "README.md",
+          "docs/getting-started.md"
+        ],
+        "tests": [
+          "tests/governance/getting-started.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/packages/cli/setup.mjs
+++ b/packages/cli/setup.mjs
@@ -66,7 +66,7 @@ export async function runSetup({ tool, project }) {
   const instructions = [];
   for (const requested of tools) {
     if (requested === "claude-code") {
-      instructions.push(`Install the Claude Code plugin with: claude plugin install ${resolve(packageRoot, "distribution/claude-code")}`);
+      instructions.push(`Install the Claude Code plugin (two steps — Claude Code installs plugins from marketplaces, not bare paths): claude plugin marketplace add ${packageRoot} && claude plugin install kdlc@kdlc`);
       instructions.push("The plugin includes session hooks: an orientation note at session start and a guard that blocks direct edits to governed knowledge-bases/ and workflow/ files (use kdlc proposal / kdlc reconcile-edits instead). Plain-language workflow guides are in its guides/ directory.");
       continue;
     }

--- a/tests/governance/cli-hints.test.mjs
+++ b/tests/governance/cli-hints.test.mjs
@@ -54,3 +54,11 @@ test("FEAT-027: hints appear only where confusion lives — populated queries an
   const failed = { ...ingestEnvelope, ok: false, result: null, error: { code: "KDLC_POLICY_DENIED", message: "no", class: 3, details: {} } };
   assert.ok(!renderEnvelope(failed, "text").includes("background job"));
 });
+
+test("FEAT-028: claude-code setup prints the two-step marketplace install", async () => {
+  const { runSetup } = await import("../../packages/cli/setup.mjs");
+  const { instructions } = await runSetup({ tool: "claude-code", project: "." });
+  const install = instructions.find((line) => line.includes("claude plugin"));
+  assert.match(install, /claude plugin marketplace add .+ && claude plugin install kdlc@kdlc/);
+  assert.ok(!install.includes("claude plugin install /"), "no bare-path install instruction remains");
+});


### PR DESCRIPTION
Closes #112

## Traceability

- Requirement IDs: FEAT-028
- Specification sections: §9.2, §25

## Summary

Claude Code no longer installs plugins from bare paths — the documented `claude plugin install <path>` fails with "not found in any configured marketplace" (hit live by a user following our instructions). Fix, mirroring the R-DLC precedent:

- Root **`.claude-plugin/marketplace.json`** exposing the `kdlc` plugin at `./distribution/claude-code`, so the working install is `claude plugin marketplace add <repo-root>` then `claude plugin install kdlc@kdlc`.
- `kdlc setup claude-code` now prints that two-step verbatim; README harness table and getting-started walkthrough updated to match.

The manifest is not in the npm `files` set (no supply-chain manifest change); no protected files; pinned suites untouched.

## Verification

Commands and results:

```text
npm test -> 287 tests, 287 pass, 0 fail (incl. getting-started walkthrough test)
claude plugin marketplace add <checkout> && claude plugin install kdlc@kdlc -> unblock commands provided to the reporting user; local marketplace.json validated against the R-DLC manifest shape that installs successfully
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

