### PR TITLE
fix: plugin manifest auto-discovery for current Claude Code validation (#112) [FEAT-028]

### DIFF
--- a/distribution/claude-code/.claude-plugin/plugin.json
+++ b/distribution/claude-code/.claude-plugin/plugin.json
@@ -1,1 +1,1 @@
-{"agents":"./agents","commands":"./commands","description":"Governed K-DLC CLI adapter","name":"kdlc","version":"0.2.0"}
+{"description":"Governed K-DLC CLI adapter","name":"kdlc","version":"0.2.0"}

--- a/packages/adapters/generate.mjs
+++ b/packages/adapters/generate.mjs
@@ -375,7 +375,10 @@ const generated = new Map([
   ],
   [
     "distribution/claude-code/.claude-plugin/plugin.json",
-    `${canonicalJson({ agents: "./agents", name: "kdlc", version: "0.2.0", description: "Governed K-DLC CLI adapter", commands: "./commands" })}\n`,
+    // agents/ and commands/ are auto-discovered at the plugin root; naming
+    // them as directory strings without a trailing slash fails current
+    // Claude Code manifest validation (FEAT-028 round 2).
+    `${canonicalJson({ name: "kdlc", version: "0.2.0", description: "Governed K-DLC CLI adapter" })}\n`,
   ],
   [
     "distribution/claude-code/COMMANDS.md",

--- a/packages/adapters/generate.mjs
+++ b/packages/adapters/generate.mjs
@@ -375,9 +375,9 @@ const generated = new Map([
   ],
   [
     "distribution/claude-code/.claude-plugin/plugin.json",
-    // agents/ and commands/ are auto-discovered at the plugin root; naming
-    // them as directory strings without a trailing slash fails current
-    // Claude Code manifest validation (FEAT-028 round 2).
+    // agents/ and commands/ are auto-discovered at the plugin root (the
+    // documented default); the previous directory-string form was rejected
+    // by current Claude Code manifest validation (FEAT-028 round 2).
     `${canonicalJson({ name: "kdlc", version: "0.2.0", description: "Governed K-DLC CLI adapter" })}\n`,
   ],
   [

--- a/tests/governance/agent-layer.test.mjs
+++ b/tests/governance/agent-layer.test.mjs
@@ -78,7 +78,10 @@ test("FEAT-012 generated Codex agents match a fresh build and keep §27.1 guidan
 test("FEAT-010 generated Claude Code agents match a fresh build", async () => {
   await execute(process.execPath, ["packages/adapters/generate.mjs", "--check"]);
   const plugin = JSON.parse(await readFile("distribution/claude-code/.claude-plugin/plugin.json", "utf8"));
-  assert.equal(plugin.agents, "./agents");
+  // Current Claude Code auto-discovers root agents/ and commands/; the
+  // manifest must not name them as slash-less directory strings (FEAT-028).
+  assert.equal(plugin.agents, undefined);
+  assert.equal(plugin.name, "kdlc");
   for (const { role } of AGENT_DEFINITIONS) {
     const generatedAgent = await readFile(`distribution/claude-code/agents/${role}.md`, "utf8");
     assert.equal(generatedAgent, renderAgentMarkdown(AGENT_DEFINITIONS.find((definition) => definition.role === role)));


### PR DESCRIPTION
Closes #112

## Traceability

- Requirement IDs: FEAT-028
- Specification sections: §9.2, §25

## Summary

Round 2 of the live install failure: with the marketplace added, `claude plugin install kdlc@kdlc` failed manifest validation ("agents: Invalid input") — current Claude Code requires directory paths in plugin.json to end with a trailing slash, or the fields omitted for auto-discovery of root `agents/` and `commands/` (per current plugins-reference docs). The generated plugin.json now uses the minimal auto-discovery form (name/version/description only), which is both valid today and immune to future path-shape tightening. Regenerated distribution; drift check green.

## Verification

Commands and results:

```text
npm test -> 288 tests, 288 pass, 0 fail
node packages/adapters/generate.mjs --check -> no drift
cat distribution/claude-code/.claude-plugin/plugin.json -> {"description":"Governed K-DLC CLI adapter","name":"kdlc","version":"0.2.0"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
