### PR TITLE
fix: accurate setup command guidance (#112) [FEAT-028]

### DIFF
--- a/distribution/claude-code/commands/kdlc-init.md
+++ b/distribution/claude-code/commands/kdlc-init.md
@@ -9,6 +9,6 @@ argument-hint: JSON string array
 
 **What you get back:** A governed project skeleton with its policy, state, and knowledge-base layout.
 
-**Usually next:** kdlc setup to configure it, then kdlc ingest to bring in your first sources.
+**Usually next:** kdlc ingest to bring in your first sources.
 
 The native Claude Code binding is `$ARGUMENTS`. Interpret it as the JSON serialization of the user argument vector and invoke ["node", "distribution/claude-code/run.mjs", "init", "--output", "json", "--host-args-json", "$ARGUMENTS"] directly without a shell. Return the exact versioned envelope and do not infer success when `ok` is false.

--- a/distribution/claude-code/commands/kdlc-setup.md
+++ b/distribution/claude-code/commands/kdlc-setup.md
@@ -3,12 +3,12 @@ description: Run the governed K-DLC setup operation
 argument-hint: JSON string array
 ---
 
-**When to use:** A project exists and you need to configure profiles, policies, or mounts.
+**When to use:** You want to install K-DLC's surface into ANOTHER tool (codex, kiro, kiro-ide, an MCP client) — from inside an already-installed harness like this one, there is nothing to set up.
 
-**What you give it:** The settings you want changed; everything else keeps its current value.
+**What you give it:** A target tool and a project directory: setup <tool> <dir>.
 
-**What you get back:** An updated, validated project configuration.
+**What you get back:** That tool's commands/agents written into the project (or install instructions).
 
-**Usually next:** kdlc status to confirm the project is healthy.
+**Usually next:** kdlc status — or just start working; this harness is already set up.
 
 The native Claude Code binding is `$ARGUMENTS`. Interpret it as the JSON serialization of the user argument vector and invoke ["node", "distribution/claude-code/run.mjs", "setup", "--output", "json", "--host-args-json", "$ARGUMENTS"] directly without a shell. Return the exact versioned envelope and do not infer success when `ok` is false.

--- a/distribution/kiro-ide/.kiro/skills/kdlc-init/SKILL.md
+++ b/distribution/kiro-ide/.kiro/skills/kdlc-init/SKILL.md
@@ -10,6 +10,6 @@ user-invocable: true
 
 **What you get back:** A governed project skeleton with its policy, state, and knowledge-base layout.
 
-**Usually next:** kdlc setup to configure it, then kdlc ingest to bring in your first sources.
+**Usually next:** kdlc ingest to bring in your first sources.
 
 Interpret the user arguments as a JSON string array and invoke ["node", "distribution/kiro-ide/run.mjs", "init", "--output", "json", "--host-args-json", <arguments-json>] directly without a shell. Return the exact versioned envelope and do not infer success when `ok` is false.

--- a/distribution/kiro-ide/.kiro/skills/kdlc-setup/SKILL.md
+++ b/distribution/kiro-ide/.kiro/skills/kdlc-setup/SKILL.md
@@ -4,12 +4,12 @@ description: Run the governed K-DLC setup operation
 user-invocable: true
 ---
 
-**When to use:** A project exists and you need to configure profiles, policies, or mounts.
+**When to use:** You want to install K-DLC's surface into ANOTHER tool (codex, kiro, kiro-ide, an MCP client) — from inside an already-installed harness like this one, there is nothing to set up.
 
-**What you give it:** The settings you want changed; everything else keeps its current value.
+**What you give it:** A target tool and a project directory: setup <tool> <dir>.
 
-**What you get back:** An updated, validated project configuration.
+**What you get back:** That tool's commands/agents written into the project (or install instructions).
 
-**Usually next:** kdlc status to confirm the project is healthy.
+**Usually next:** kdlc status — or just start working; this harness is already set up.
 
 Interpret the user arguments as a JSON string array and invoke ["node", "distribution/kiro-ide/run.mjs", "setup", "--output", "json", "--host-args-json", <arguments-json>] directly without a shell. Return the exact versioned envelope and do not infer success when `ok` is false.

--- a/distribution/kiro/.kiro/skills/kdlc-init/SKILL.md
+++ b/distribution/kiro/.kiro/skills/kdlc-init/SKILL.md
@@ -10,6 +10,6 @@ user-invocable: true
 
 **What you get back:** A governed project skeleton with its policy, state, and knowledge-base layout.
 
-**Usually next:** kdlc setup to configure it, then kdlc ingest to bring in your first sources.
+**Usually next:** kdlc ingest to bring in your first sources.
 
 Interpret the user arguments as a JSON string array and invoke ["node", "distribution/kiro/run.mjs", "init", "--output", "json", "--host-args-json", <arguments-json>] directly without a shell. Return the exact versioned envelope and do not infer success when `ok` is false.

--- a/distribution/kiro/.kiro/skills/kdlc-setup/SKILL.md
+++ b/distribution/kiro/.kiro/skills/kdlc-setup/SKILL.md
@@ -4,12 +4,12 @@ description: Run the governed K-DLC setup operation
 user-invocable: true
 ---
 
-**When to use:** A project exists and you need to configure profiles, policies, or mounts.
+**When to use:** You want to install K-DLC's surface into ANOTHER tool (codex, kiro, kiro-ide, an MCP client) — from inside an already-installed harness like this one, there is nothing to set up.
 
-**What you give it:** The settings you want changed; everything else keeps its current value.
+**What you give it:** A target tool and a project directory: setup <tool> <dir>.
 
-**What you get back:** An updated, validated project configuration.
+**What you get back:** That tool's commands/agents written into the project (or install instructions).
 
-**Usually next:** kdlc status to confirm the project is healthy.
+**Usually next:** kdlc status — or just start working; this harness is already set up.
 
 Interpret the user arguments as a JSON string array and invoke ["node", "distribution/kiro/run.mjs", "setup", "--output", "json", "--host-args-json", <arguments-json>] directly without a shell. Return the exact versioned envelope and do not infer success when `ok` is false.

--- a/packages/adapters/generate.mjs
+++ b/packages/adapters/generate.mjs
@@ -19,10 +19,10 @@ const COMMAND_GUIDANCE = {
     next: "kdlc setup to configure it, then kdlc ingest to bring in your first sources.",
   },
   setup: {
-    when: "A project exists and you need to configure profiles, policies, or mounts.",
-    give: "The settings you want changed; everything else keeps its current value.",
-    get: "An updated, validated project configuration.",
-    next: "kdlc status to confirm the project is healthy.",
+    when: "You want to install K-DLC's surface into ANOTHER tool (codex, kiro, kiro-ide, an MCP client) — from inside an already-installed harness like this one, there is nothing to set up.",
+    give: "A target tool and a project directory: setup <tool> <dir>.",
+    get: "That tool's commands/agents written into the project (or install instructions).",
+    next: "kdlc status — or just start working; this harness is already set up.",
   },
   adopt: {
     when: "Existing documents or knowledge should be brought under K-DLC governance.",

--- a/packages/adapters/generate.mjs
+++ b/packages/adapters/generate.mjs
@@ -16,7 +16,7 @@ const COMMAND_GUIDANCE = {
     when: "You're starting a brand-new K-DLC project in this repository.",
     give: "A project name and, optionally, a scope profile.",
     get: "A governed project skeleton with its policy, state, and knowledge-base layout.",
-    next: "kdlc setup to configure it, then kdlc ingest to bring in your first sources.",
+    next: "kdlc ingest to bring in your first sources.",
   },
   setup: {
     when: "You want to install K-DLC's surface into ANOTHER tool (codex, kiro, kiro-ide, an MCP client) — from inside an already-installed harness like this one, there is nothing to set up.",


### PR DESCRIPTION
Closes #112

## Traceability

- Requirement IDs: FEAT-028
- Specification sections: §9.2, §25

## Summary

Live-use finding: the `/kdlc:setup` guidance said the command "configures profiles, policies, or mounts" — but `setup` is the harness-surface installer. Inside an installed harness, an assistant reading that guidance reasonably offers to run it, which is circular (it would print plugin-install instructions for the harness the user is already in — exactly what happened in a user session). The guidance now states what setup does, its arguments, and that inside an installed harness there is nothing to set up. Regenerated 3 command surfaces per harness; drift check green.

## Verification

Commands and results:

```text
npm test -> 288 tests, 288 pass, 0 fail
node packages/adapters/generate.mjs --check -> no drift
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
