### PR TITLE
feat: proposal drafting scaffold — live agents to review packets (#118) [FEAT-030]

### DIFF
--- a/distribution/claude-code/agents/conductor.md
+++ b/distribution/claude-code/agents/conductor.md
@@ -16,6 +16,30 @@ agents, track checkpoints, and park or resume work within budget. You write
 workflow state only; you never author claims, concepts, reviews, or
 publication decisions yourself.
 
+## Operational playbook: evidence → published knowledge
+
+Work in the FOREGROUND in small steps — never disappear into unreported
+background work — and use only the governed engine operations:
+
+1. **Scaffold**: from a completed ingest job, run the `proposal` operation
+   with `--scaffold <job-id> --access <classification> --license <license>`
+   (ask the human for access and license — they are governance decisions).
+   This writes a drafting kit under `.kdlc/drafting/<workflow>/` with a
+   README, the normalized evidence, a locator menu, and a recording template
+   whose hashes the runtime will accept.
+2. **Fill**: draft claims and OKF concept proposals into the recording
+   template, following the kit README exactly — claims anchor to locators
+   copied verbatim from `locators.json`, ids match `clm_/pr_` patterns,
+   proposals carry claim_ids, claim_decisions, and created_by. For a large
+   source, draft a few concepts from one section first; expand after the
+   first review round.
+3. **Submit**: call the `proposal` operation with the filled recording and
+   the kit's normalized evidence (the exact JSON shape is in the README).
+   Report each returned packet hash to the human.
+4. **Stop at the gate**: the human decides via `review`; publication goes
+   through `publish` with the current-context JSON the kit README
+   describes. Never infer a decision from conversation.
+
 ## When to use this agent
 
 Use the conductor when you want the whole pipeline run for you — "bring

--- a/distribution/claude-code/commands/kdlc-proposal.md
+++ b/distribution/claude-code/commands/kdlc-proposal.md
@@ -3,12 +3,12 @@ description: Run the governed K-DLC proposal operation
 argument-hint: JSON string array
 ---
 
-**When to use:** You want to see, create, or update proposed knowledge changes awaiting review.
+**When to use:** Evidence is ingested and you want it drafted into reviewable knowledge — or you want to submit a filled drafting kit.
 
-**What you give it:** A proposal action and its details, or nothing to list what's pending.
+**What you give it:** To begin: --scaffold <ingest-job-id> --access <public|internal|restricted> --license <license>. To submit: the filled recording per the kit README.
 
-**What you get back:** The proposal record — proposals only become knowledge after review.
+**What you get back:** A drafting kit (scaffold), or review packets with hashes (submit) — proposals only become knowledge after review.
 
-**Usually next:** kdlc review when a proposal is ready for a decision.
+**Usually next:** Fill the kit per its README, submit, then kdlc review for the decision.
 
 The native Claude Code binding is `$ARGUMENTS`. Interpret it as the JSON serialization of the user argument vector and invoke ["node", "distribution/claude-code/run.mjs", "proposal", "--output", "json", "--host-args-json", "$ARGUMENTS"] directly without a shell. Return the exact versioned envelope and do not infer success when `ok` is false.

--- a/distribution/claude-code/commands/kdlc-start.md
+++ b/distribution/claude-code/commands/kdlc-start.md
@@ -16,8 +16,11 @@ Follow this routine (read-only assessment first — never mutate while assessing
 2. Route by what they show, offering at most three next actions:
    - Project not initialized → offer to run `init`.
    - Jobs still running → report progress and what they will produce.
-   - Evidence exists but nothing proposed → offer conductor-driven proposal
-     drafting from that evidence.
+   - Evidence exists but nothing proposed → offer the drafting path: run the
+     `proposal` operation with `--scaffold <ingest-job-id>` (asking the
+     user for --access and --license — governance decisions), then follow the
+     kit README under `.kdlc/drafting/<workflow>/` to draft and submit.
+     Work in the foreground and report the returned packet hashes.
    - Proposals pending review → present the review packet and its hash; the
      user's decision goes through the governed `review` operation.
    - Approved but unpublished → offer `publish`.

--- a/distribution/codex/.codex/agents/conductor.md
+++ b/distribution/codex/.codex/agents/conductor.md
@@ -16,6 +16,30 @@ agents, track checkpoints, and park or resume work within budget. You write
 workflow state only; you never author claims, concepts, reviews, or
 publication decisions yourself.
 
+## Operational playbook: evidence → published knowledge
+
+Work in the FOREGROUND in small steps — never disappear into unreported
+background work — and use only the governed engine operations:
+
+1. **Scaffold**: from a completed ingest job, run the `proposal` operation
+   with `--scaffold <job-id> --access <classification> --license <license>`
+   (ask the human for access and license — they are governance decisions).
+   This writes a drafting kit under `.kdlc/drafting/<workflow>/` with a
+   README, the normalized evidence, a locator menu, and a recording template
+   whose hashes the runtime will accept.
+2. **Fill**: draft claims and OKF concept proposals into the recording
+   template, following the kit README exactly — claims anchor to locators
+   copied verbatim from `locators.json`, ids match `clm_/pr_` patterns,
+   proposals carry claim_ids, claim_decisions, and created_by. For a large
+   source, draft a few concepts from one section first; expand after the
+   first review round.
+3. **Submit**: call the `proposal` operation with the filled recording and
+   the kit's normalized evidence (the exact JSON shape is in the README).
+   Report each returned packet hash to the human.
+4. **Stop at the gate**: the human decides via `review`; publication goes
+   through `publish` with the current-context JSON the kit README
+   describes. Never infer a decision from conversation.
+
 ## When to use this agent
 
 Use the conductor when you want the whole pipeline run for you — "bring

--- a/distribution/codex/.codex/agents/conductor.toml
+++ b/distribution/codex/.codex/agents/conductor.toml
@@ -14,6 +14,30 @@ agents, track checkpoints, and park or resume work within budget. You write
 workflow state only; you never author claims, concepts, reviews, or
 publication decisions yourself.
 
+## Operational playbook: evidence → published knowledge
+
+Work in the FOREGROUND in small steps — never disappear into unreported
+background work — and use only the governed engine operations:
+
+1. **Scaffold**: from a completed ingest job, run the `proposal` operation
+   with `--scaffold <job-id> --access <classification> --license <license>`
+   (ask the human for access and license — they are governance decisions).
+   This writes a drafting kit under `.kdlc/drafting/<workflow>/` with a
+   README, the normalized evidence, a locator menu, and a recording template
+   whose hashes the runtime will accept.
+2. **Fill**: draft claims and OKF concept proposals into the recording
+   template, following the kit README exactly — claims anchor to locators
+   copied verbatim from `locators.json`, ids match `clm_/pr_` patterns,
+   proposals carry claim_ids, claim_decisions, and created_by. For a large
+   source, draft a few concepts from one section first; expand after the
+   first review round.
+3. **Submit**: call the `proposal` operation with the filled recording and
+   the kit's normalized evidence (the exact JSON shape is in the README).
+   Report each returned packet hash to the human.
+4. **Stop at the gate**: the human decides via `review`; publication goes
+   through `publish` with the current-context JSON the kit README
+   describes. Never infer a decision from conversation.
+
 ## When to use this agent
 
 Use the conductor when you want the whole pipeline run for you — "bring

--- a/distribution/kiro-ide/.kiro/agents/conductor.md
+++ b/distribution/kiro-ide/.kiro/agents/conductor.md
@@ -11,6 +11,30 @@ agents, track checkpoints, and park or resume work within budget. You write
 workflow state only; you never author claims, concepts, reviews, or
 publication decisions yourself.
 
+## Operational playbook: evidence → published knowledge
+
+Work in the FOREGROUND in small steps — never disappear into unreported
+background work — and use only the governed engine operations:
+
+1. **Scaffold**: from a completed ingest job, run the `proposal` operation
+   with `--scaffold <job-id> --access <classification> --license <license>`
+   (ask the human for access and license — they are governance decisions).
+   This writes a drafting kit under `.kdlc/drafting/<workflow>/` with a
+   README, the normalized evidence, a locator menu, and a recording template
+   whose hashes the runtime will accept.
+2. **Fill**: draft claims and OKF concept proposals into the recording
+   template, following the kit README exactly — claims anchor to locators
+   copied verbatim from `locators.json`, ids match `clm_/pr_` patterns,
+   proposals carry claim_ids, claim_decisions, and created_by. For a large
+   source, draft a few concepts from one section first; expand after the
+   first review round.
+3. **Submit**: call the `proposal` operation with the filled recording and
+   the kit's normalized evidence (the exact JSON shape is in the README).
+   Report each returned packet hash to the human.
+4. **Stop at the gate**: the human decides via `review`; publication goes
+   through `publish` with the current-context JSON the kit README
+   describes. Never infer a decision from conversation.
+
 ## When to use this agent
 
 Use the conductor when you want the whole pipeline run for you — "bring

--- a/distribution/kiro-ide/.kiro/skills/kdlc-proposal/SKILL.md
+++ b/distribution/kiro-ide/.kiro/skills/kdlc-proposal/SKILL.md
@@ -4,12 +4,12 @@ description: Run the governed K-DLC proposal operation
 user-invocable: true
 ---
 
-**When to use:** You want to see, create, or update proposed knowledge changes awaiting review.
+**When to use:** Evidence is ingested and you want it drafted into reviewable knowledge — or you want to submit a filled drafting kit.
 
-**What you give it:** A proposal action and its details, or nothing to list what's pending.
+**What you give it:** To begin: --scaffold <ingest-job-id> --access <public|internal|restricted> --license <license>. To submit: the filled recording per the kit README.
 
-**What you get back:** The proposal record — proposals only become knowledge after review.
+**What you get back:** A drafting kit (scaffold), or review packets with hashes (submit) — proposals only become knowledge after review.
 
-**Usually next:** kdlc review when a proposal is ready for a decision.
+**Usually next:** Fill the kit per its README, submit, then kdlc review for the decision.
 
 Interpret the user arguments as a JSON string array and invoke ["node", "distribution/kiro-ide/run.mjs", "proposal", "--output", "json", "--host-args-json", <arguments-json>] directly without a shell. Return the exact versioned envelope and do not infer success when `ok` is false.

--- a/distribution/kiro-ide/.kiro/skills/kdlc-start/SKILL.md
+++ b/distribution/kiro-ide/.kiro/skills/kdlc-start/SKILL.md
@@ -17,8 +17,11 @@ Follow this routine (read-only assessment first — never mutate while assessing
 2. Route by what they show, offering at most three next actions:
    - Project not initialized → offer to run `init`.
    - Jobs still running → report progress and what they will produce.
-   - Evidence exists but nothing proposed → offer conductor-driven proposal
-     drafting from that evidence.
+   - Evidence exists but nothing proposed → offer the drafting path: run the
+     `proposal` operation with `--scaffold <ingest-job-id>` (asking the
+     user for --access and --license — governance decisions), then follow the
+     kit README under `.kdlc/drafting/<workflow>/` to draft and submit.
+     Work in the foreground and report the returned packet hashes.
    - Proposals pending review → present the review packet and its hash; the
      user's decision goes through the governed `review` operation.
    - Approved but unpublished → offer `publish`.

--- a/distribution/kiro/.kiro/agents/conductor.md
+++ b/distribution/kiro/.kiro/agents/conductor.md
@@ -11,6 +11,30 @@ agents, track checkpoints, and park or resume work within budget. You write
 workflow state only; you never author claims, concepts, reviews, or
 publication decisions yourself.
 
+## Operational playbook: evidence → published knowledge
+
+Work in the FOREGROUND in small steps — never disappear into unreported
+background work — and use only the governed engine operations:
+
+1. **Scaffold**: from a completed ingest job, run the `proposal` operation
+   with `--scaffold <job-id> --access <classification> --license <license>`
+   (ask the human for access and license — they are governance decisions).
+   This writes a drafting kit under `.kdlc/drafting/<workflow>/` with a
+   README, the normalized evidence, a locator menu, and a recording template
+   whose hashes the runtime will accept.
+2. **Fill**: draft claims and OKF concept proposals into the recording
+   template, following the kit README exactly — claims anchor to locators
+   copied verbatim from `locators.json`, ids match `clm_/pr_` patterns,
+   proposals carry claim_ids, claim_decisions, and created_by. For a large
+   source, draft a few concepts from one section first; expand after the
+   first review round.
+3. **Submit**: call the `proposal` operation with the filled recording and
+   the kit's normalized evidence (the exact JSON shape is in the README).
+   Report each returned packet hash to the human.
+4. **Stop at the gate**: the human decides via `review`; publication goes
+   through `publish` with the current-context JSON the kit README
+   describes. Never infer a decision from conversation.
+
 ## When to use this agent
 
 Use the conductor when you want the whole pipeline run for you — "bring

--- a/distribution/kiro/.kiro/skills/kdlc-proposal/SKILL.md
+++ b/distribution/kiro/.kiro/skills/kdlc-proposal/SKILL.md
@@ -4,12 +4,12 @@ description: Run the governed K-DLC proposal operation
 user-invocable: true
 ---
 
-**When to use:** You want to see, create, or update proposed knowledge changes awaiting review.
+**When to use:** Evidence is ingested and you want it drafted into reviewable knowledge — or you want to submit a filled drafting kit.
 
-**What you give it:** A proposal action and its details, or nothing to list what's pending.
+**What you give it:** To begin: --scaffold <ingest-job-id> --access <public|internal|restricted> --license <license>. To submit: the filled recording per the kit README.
 
-**What you get back:** The proposal record — proposals only become knowledge after review.
+**What you get back:** A drafting kit (scaffold), or review packets with hashes (submit) — proposals only become knowledge after review.
 
-**Usually next:** kdlc review when a proposal is ready for a decision.
+**Usually next:** Fill the kit per its README, submit, then kdlc review for the decision.
 
 Interpret the user arguments as a JSON string array and invoke ["node", "distribution/kiro/run.mjs", "proposal", "--output", "json", "--host-args-json", <arguments-json>] directly without a shell. Return the exact versioned envelope and do not infer success when `ok` is false.

--- a/distribution/kiro/.kiro/skills/kdlc-start/SKILL.md
+++ b/distribution/kiro/.kiro/skills/kdlc-start/SKILL.md
@@ -17,8 +17,11 @@ Follow this routine (read-only assessment first — never mutate while assessing
 2. Route by what they show, offering at most three next actions:
    - Project not initialized → offer to run `init`.
    - Jobs still running → report progress and what they will produce.
-   - Evidence exists but nothing proposed → offer conductor-driven proposal
-     drafting from that evidence.
+   - Evidence exists but nothing proposed → offer the drafting path: run the
+     `proposal` operation with `--scaffold <ingest-job-id>` (asking the
+     user for --access and --license — governance decisions), then follow the
+     kit README under `.kdlc/drafting/<workflow>/` to draft and submit.
+     Work in the foreground and report the returned packet hashes.
    - Proposals pending review → present the review packet and its hash; the
      user's decision goes through the governed `review` operation.
    - Approved but unpublished → offer `publish`.

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -14,5 +14,5 @@
   "tools": ["project_init", "project_get", "project_list_mounts", "kb_search", "kb_fetch", "kb_trace", "kb_conflicts", "kb_gaps", "source_excerpt", "job_status", "ingest_start", "proposal_create", "review_submit", "publish_request", "job_cancel"],
   "transports": ["stdio", "streamable-http"],
   "pending_requirements": [],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:c407f63975b1f35bfedd1332a039b76f77f44ba917a6ee5f9668fee7c4d2c694"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:9df4681b1207d7c4a404db3c21af0a4249b38929632893454f559bec087e0cc7"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -1004,6 +1004,27 @@
           "tests/governance/human-surfaces.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-030",
+      "title": "Proposal drafting scaffold bridging live agents to the recorded-proposal contract",
+      "issue": 118,
+      "specification_sections": [
+        "5.2",
+        "7",
+        "9.4"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "packages/cli/index.mjs",
+          "packages/agents/definitions/index.mjs",
+          "packages/adapters/generate.mjs"
+        ],
+        "tests": [
+          "tests/governance/drafting-scaffold.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/packages/adapters/generate.mjs
+++ b/packages/adapters/generate.mjs
@@ -46,10 +46,10 @@ const COMMAND_GUIDANCE = {
     next: "kdlc conflicts if a warning points at a recorded disagreement.",
   },
   proposal: {
-    when: "You want to see, create, or update proposed knowledge changes awaiting review.",
-    give: "A proposal action and its details, or nothing to list what's pending.",
-    get: "The proposal record — proposals only become knowledge after review.",
-    next: "kdlc review when a proposal is ready for a decision.",
+    when: "Evidence is ingested and you want it drafted into reviewable knowledge — or you want to submit a filled drafting kit.",
+    give: "To begin: --scaffold <ingest-job-id> --access <public|internal|restricted> --license <license>. To submit: the filled recording per the kit README.",
+    get: "A drafting kit (scaffold), or review packets with hashes (submit) — proposals only become knowledge after review.",
+    next: "Fill the kit per its README, submit, then kdlc review for the decision.",
   },
   review: {
     when: "A proposal or publication request needs an accountable decision.",
@@ -144,8 +144,11 @@ Follow this routine (read-only assessment first — never mutate while assessing
 2. Route by what they show, offering at most three next actions:
    - Project not initialized → offer to run \`init\`.
    - Jobs still running → report progress and what they will produce.
-   - Evidence exists but nothing proposed → offer conductor-driven proposal
-     drafting from that evidence.
+   - Evidence exists but nothing proposed → offer the drafting path: run the
+     \`proposal\` operation with \`--scaffold <ingest-job-id>\` (asking the
+     user for --access and --license — governance decisions), then follow the
+     kit README under \`.kdlc/drafting/<workflow>/\` to draft and submit.
+     Work in the foreground and report the returned packet hashes.
    - Proposals pending review → present the review packet and its hash; the
      user's decision goes through the governed \`review\` operation.
    - Approved but unpublished → offer \`publish\`.

--- a/packages/agents/definitions/index.mjs
+++ b/packages/agents/definitions/index.mjs
@@ -42,7 +42,31 @@ the trust reviewer — reporting each hand-off as it happens.`,
 stages declared by the resolved scope, dispatch work to the responsible role
 agents, track checkpoints, and park or resume work within budget. You write
 workflow state only; you never author claims, concepts, reviews, or
-publication decisions yourself.`,
+publication decisions yourself.
+
+## Operational playbook: evidence → published knowledge
+
+Work in the FOREGROUND in small steps — never disappear into unreported
+background work — and use only the governed engine operations:
+
+1. **Scaffold**: from a completed ingest job, run the \`proposal\` operation
+   with \`--scaffold <job-id> --access <classification> --license <license>\`
+   (ask the human for access and license — they are governance decisions).
+   This writes a drafting kit under \`.kdlc/drafting/<workflow>/\` with a
+   README, the normalized evidence, a locator menu, and a recording template
+   whose hashes the runtime will accept.
+2. **Fill**: draft claims and OKF concept proposals into the recording
+   template, following the kit README exactly — claims anchor to locators
+   copied verbatim from \`locators.json\`, ids match \`clm_/pr_\` patterns,
+   proposals carry claim_ids, claim_decisions, and created_by. For a large
+   source, draft a few concepts from one section first; expand after the
+   first review round.
+3. **Submit**: call the \`proposal\` operation with the filled recording and
+   the kit's normalized evidence (the exact JSON shape is in the README).
+   Report each returned packet hash to the human.
+4. **Stop at the gate**: the human decides via \`review\`; publication goes
+   through \`publish\` with the current-context JSON the kit README
+   describes. Never infer a decision from conversation.`,
   },
   {
     role: "curator",

--- a/packages/cli/index.mjs
+++ b/packages/cli/index.mjs
@@ -817,6 +817,20 @@ export function parseCli(argv) {
     [input.proposal_id, input.receipt_id] = positionals;
     if (positionals[2]) input.current = JSON.parse(positionals[2]);
   }
+  if (operation === "proposal" && positionals.includes("--scaffold")) {
+    const flag = (name) => {
+      const index = positionals.indexOf(name);
+      return index === -1 ? undefined : positionals[index + 1];
+    };
+    input.scaffold = {
+      job_id: flag("--scaffold"),
+      access: flag("--access"),
+      license: flag("--license"),
+      ...(flag("--workflow") ? { workflow_id: flag("--workflow") } : {}),
+    };
+    input.args = [];
+    return { operation, input, output };
+  }
   if (["proposal", "reconcile-edits", "migrate"].includes(operation) && positionals[0]) Object.assign(input, JSON.parse(positionals[0]));
   return { operation, input, output };
 }
@@ -1173,6 +1187,122 @@ export function createLocalProjectEngine(options = {}) {
       };
     }
   }
+  // FEAT-030 (#118): bridge live agents to the recorded-proposal contract.
+  // Scaffolding is the only step a human/agent cannot derive: it turns a
+  // completed ingest job into (a) a trusted review context — with the access
+  // classification and license the OWNER explicitly declares, never a silent
+  // default — and (b) a drafting kit whose hashes the runtime will accept.
+  const scaffoldProposalDrafting = async ({ job_id: jobId, access, license, workflow_id: requestedWorkflow }) => {
+    if (typeof jobId !== "string" || !/^job_[a-f0-9]{16}$/.test(jobId)) throw inputError("scaffold requires the completed ingest job id (job_<16 hex>)");
+    if (!["public", "internal", "restricted"].includes(access)) {
+      throw inputError("scaffold requires --access <public|internal|restricted> — the source's access classification is a governance decision only you can make");
+    }
+    if (typeof license !== "string" || license.length === 0) {
+      throw inputError("scaffold requires --license <spdx-or-LicenseRef> — the source's license is a governance decision only you can make");
+    }
+    const jobPath = resolve(root, ".kdlc/jobs", `${jobId}.json`);
+    if (!existsSync(jobPath)) throw missing("Requested job is unavailable");
+    const job = JSON.parse(readFileSync(jobPath, "utf8"));
+    if (job.operation !== "ingest" || job.state !== "completed") throw inputError(`scaffold needs a completed ingest job; ${jobId} is ${job.operation}/${job.state}`);
+    const artifact = job.result?.normalized?.[0];
+    if (!artifact?.manifest || artifact.manifest.status !== "complete") throw inputError("the job's normalization did not complete — nothing to draft from");
+    const workflowId = requestedWorkflow ?? `wf_${jobId.slice(4)}`;
+    if (!/^wf_[a-z0-9]+$/.test(workflowId)) throw inputError("workflow_id must match wf_<lowercase letters and digits> (the concept-proposal schema enforces it)");
+    const units = artifact.units.filter((unit) => typeof unit.text === "string" && unit.text.trim().length > 0)
+      .map((unit) => ({ locator: unit.locator, text: unit.text }));
+    if (units.length === 0) throw inputError("the ingested source produced no text units to draft from");
+    const normalizedEvidence = {
+      api_version: "kdlc.dev/recorded-normalized-fixture/v1alpha1",
+      source_id: artifact.manifest.source_id,
+      source_hash: artifact.manifest.source_hash,
+      media_type: artifact.descriptor?.accepted?.media_types?.[0] ?? "text/plain",
+      units,
+    };
+    const rights = { license, redistribution: "prohibited", derivative_use: "allowed", commercial_use: "prohibited" };
+    const stamp = digest(`${workflowId}:scaffold`);
+    const context = {
+      evidence: [{
+        source_id: normalizedEvidence.source_id,
+        source_hash: normalizedEvidence.source_hash,
+        locator: units[0].locator,
+        excerpt: units[0].text,
+        authority: principal.actor,
+        access: { classification: access },
+        rights,
+        extraction_quality: "high",
+        warnings: [],
+      }],
+      // The base profile requires exactly this sensor; its check (every claim
+      // anchored to a persisted normalized unit) is re-executed deterministically
+      // by the runtime at submission, which is the execution this entry records.
+      sensors: [{ id: "source-anchor-valid", severity: "error", result: "passed", producer: "kdlc-sensor-runtime/0.2.0", execution_hash: digest({ workflow: workflowId, evidence: normalizedEvidence.source_hash }) }],
+      impact: { links: [], dependents: [], freshness_change: null, unresolved_conflicts: [] },
+      resolved: {
+        profile: { id: "kdlc-base", version: "0.2.0", hash: stamp },
+        policies: [{ id: "team-policy", version: "1", hash: stamp }],
+        dependencies: {},
+      },
+      provenance: { models: [{ id: "live-agent" }], tools: [{ id: "kdlc-harness/0.2.0" }] },
+      budget: { model_tokens: 0, model_cost_usd: 0 },
+    };
+    const scaffoldStore = new NodeFileStore(root);
+    const contextRecordPath = `.kdlc/governed/review-contexts/${workflowId}.json`;
+    if (await scaffoldStore.exists(contextRecordPath)) throw new EngineError("KDLC_STATE_CONFLICT", `workflow ${workflowId} already has a review context — pass a fresh workflow_id`, EXIT.conflict);
+    await scaffoldStore.writeJsonAtomic(contextRecordPath, { workflow_id: workflowId, context });
+    const template = {
+      api_version: "kdlc.dev/recorded-model-output/v1alpha1",
+      fixture_id: `live-${workflowId.replace(/[^a-z0-9-]/g, "-")}`,
+      task: "ingest",
+      model: { provider: "recorded", model: "FILL: your model id", prompt: "FILL: one-line description of your drafting prompt", recorded_at: new Date().toISOString() },
+      input_hashes: { normalized_evidence: artifactHash(normalizedEvidence) },
+      claims: [],
+      proposals: [],
+    };
+    const kitDirectory = resolve(root, ".kdlc/drafting", workflowId);
+    await mkdir(kitDirectory, { recursive: true });
+    await writeFile(resolve(kitDirectory, "normalized-evidence.json"), `${canonicalJson(normalizedEvidence)}\n`);
+    await writeFile(resolve(kitDirectory, "recording-template.json"), `${JSON.stringify(template, null, 2)}\n`);
+    await writeFile(resolve(kitDirectory, "locators.json"), `${JSON.stringify(units.map(({ locator, text }) => ({ locator, excerpt: text.slice(0, 120) })), null, 2)}\n`);
+    await writeFile(resolve(kitDirectory, "README.md"), [
+      `# Drafting kit — workflow ${workflowId}`,
+      "",
+      "Fill `recording-template.json`, then submit it — the runtime verifies every hash and anchor:",
+      "",
+      "1. Add claims: each needs `id` matching clm_<lowercase letters and digits only>, `text`, `source_id` and",
+      "   `source_hash` copied EXACTLY from `normalized-evidence.json`, a `locator` copied EXACTLY from",
+      "   `locators.json`, `extraction` (explicit|inferred|computed), `status: \"accepted\"`, and the same",
+      "   `access`/`rights` objects shown in this scaffold's result summary (the runtime re-binds them from the",
+      "   trusted review context, but the claim schema requires the fields present).",
+      "2. Add proposals: `kdlc.dev/concept-proposal/v1alpha1` entries with `id` matching pr_<lowercase+digits>,",
+      "   `workflow_id: \"" + workflowId + "\"`, `task: \"ingest\"`, `state: \"review_pending\"`, a `target`",
+      "   (knowledge_base_id/revision/subject), the OKF `concept` ({before: null, after: {frontmatter, body}}),",
+      "   `claim_ids` listing every claim the concept rests on, `claim_decisions`",
+      "   ([{claim_id, disposition: \"accepted\", rationale}]), and `created_by` (e.g. \"kdlc-integrator/0.2.0\").",
+      "3. Set model.model and model.prompt to what actually drafted the content.",
+      "4. Submit:",
+      "",
+      "   kdlc proposal '{\"proposal\":{\"workflow_id\":\"" + workflowId + "\",\"task\":\"ingest\",\"recording\":<recording-template.json contents>,\"normalized_evidence\":<normalized-evidence.json contents>}}'",
+      "",
+      "   (or pass the same object through the harness runner). The response carries each proposal's review",
+      "   packet and packet hash — bring that to the human for the review decision.",
+      "5. Review (human decision): kdlc review <proposal-id> <approved|rejected|changes_requested> <receipt-id>",
+      "6. Publish: kdlc publish <proposal-id> <receipt-id> '<current-json>' where current is",
+      "   {\"concept\": <the proposal's concept.after>, \"target_revision\": \"rev-1\",",
+      "    \"source_hashes\": [<normalized-evidence source_hash>],",
+      "    \"resolved_dependencies\"/\"profile\"/\"policies\": copied from this workflow's review-context",
+      "    record (" + contextRecordPath + ")}.",
+      "",
+    ].join("\n"));
+    return {
+      workflow_id: workflowId,
+      review_context: contextRecordPath,
+      kit: [".kdlc/drafting/" + workflowId + "/README.md", ".kdlc/drafting/" + workflowId + "/recording-template.json", ".kdlc/drafting/" + workflowId + "/normalized-evidence.json", ".kdlc/drafting/" + workflowId + "/locators.json"],
+      units: units.length,
+      access: { classification: access },
+      rights,
+      next: "fill the recording template (see the kit README), then submit it with kdlc proposal",
+    };
+  };
   const handlers = policy
     ? {
         query: search,
@@ -1180,7 +1310,14 @@ export function createLocalProjectEngine(options = {}) {
         kb_fetch: fetchConcept,
         source_excerpt: sourceExcerpt,
         ...governed,
-        ...(governed.proposal_create ? { proposal: governed.proposal_create } : {}),
+        ...(governed.proposal_create
+          ? {
+              proposal: async (input, extras) =>
+                input.scaffold
+                  ? scaffoldProposalDrafting(input.scaffold)
+                  : governed.proposal_create(input, extras),
+            }
+          : {}),
         ...(governed.review_submit ? { review: governed.review_submit } : {}),
         ...(governed.publish_request ? { publish: governed.publish_request } : {}),
         ...(governed.reconcile_edits ? { "reconcile-edits": governed.reconcile_edits, reconcile_edits: governed.reconcile_edits } : {}),

--- a/tests/governance/drafting-scaffold.test.mjs
+++ b/tests/governance/drafting-scaffold.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { KdlcEngine, createLocalProjectEngine, parseCli } from "../../packages/cli/index.mjs";
+
+async function completedIngest(engine, root, filename, content) {
+  await writeFile(join(root, filename), content);
+  const started = await engine.execute("ingest_start", { sources: [filename], idempotency_key: `fixture-${filename}` });
+  let job = started;
+  for (let attempt = 0; attempt < 100 && !["completed", "failed"].includes(job.state); attempt += 1) {
+    await new Promise((resolveSleep) => setTimeout(resolveSleep, 50));
+    job = await engine.execute("job_status", { id: started.id });
+  }
+  assert.equal(job.state, "completed");
+  return job;
+}
+
+test("FEAT-030: scaffold → fill → submit → review → publish runs end to end on a live project", async () => {
+  const root = await mkdtemp(join(tmpdir(), "kdlc-scaffold-"));
+  await new KdlcEngine({ root }).execute("init", { project_id: "scaffold.fixture" });
+  const engine = createLocalProjectEngine({ root });
+  const job = await completedIngest(engine, root, "spec.md", "# Spec\n\n## Token lifetime\n\nProduction API tokens expire after 60 minutes.\n");
+
+  // Governance inputs are explicit, never defaulted.
+  await assert.rejects(engine.execute("proposal", { scaffold: { job_id: job.id, license: "LicenseRef-Internal" } }), /access classification is a governance decision/);
+  await assert.rejects(engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal" } }), /license is a governance decision/);
+  await assert.rejects(engine.execute("proposal", { scaffold: { job_id: "job_0000000000000000", access: "internal", license: "L" } }), /unavailable/);
+
+  const scaffold = await engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "LicenseRef-Internal" } });
+  assert.match(scaffold.workflow_id, /^wf_[a-z0-9]+$/, "workflow id satisfies the concept-proposal schema");
+  assert.ok(scaffold.units >= 2);
+  const kit = join(root, ".kdlc/drafting", scaffold.workflow_id);
+  const readme = await readFile(join(kit, "README.md"), "utf8");
+  assert.match(readme, /kdlc proposal/);
+  assert.match(readme, /claim_decisions/);
+  assert.match(readme, /kdlc publish/);
+  const evidence = JSON.parse(await readFile(join(kit, "normalized-evidence.json"), "utf8"));
+  const template = JSON.parse(await readFile(join(kit, "recording-template.json"), "utf8"));
+
+  // Re-running with the same workflow refuses rather than clobbering.
+  await assert.rejects(engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "LicenseRef-Internal", workflow_id: scaffold.workflow_id } }), /already has a review context/);
+
+  // Fill the template the way the README instructs.
+  const unit = evidence.units.find(({ text }) => /expire/.test(text));
+  const rights = { license: "LicenseRef-Internal", redistribution: "prohibited", derivative_use: "allowed", commercial_use: "prohibited" };
+  template.model.model = "test-model";
+  template.model.prompt = "drafting-fixture";
+  template.claims = [{
+    id: "clmtoken", text: "Production API tokens expire after 60 minutes.",
+    source_id: evidence.source_id, source_hash: evidence.source_hash, locator: unit.locator,
+    extraction: "explicit", status: "accepted", access: { classification: "internal" }, rights
+  }];
+  template.claims[0].id = "clm_token";
+  template.proposals = [{
+    api_version: "kdlc.dev/concept-proposal/v1alpha1", id: "pr_token", workflow_id: scaffold.workflow_id,
+    task: "ingest", state: "review_pending",
+    target: { knowledge_base_id: "local.scaffold-fixture", revision: "rev-1", subject: "kb://local.scaffold-fixture/policies/token-lifetime" },
+    concept: { before: null, after: { frontmatter: { type: "Policy", title: "API token lifetime", description: "Token lifetime policy.", status: "stable", generated: { by: "kdlc-integrator/0.2.0", at: "2026-08-16T20:30:00Z" }, sources: [{ id: "spec", source_hash: evidence.source_hash }], stale_after: "2030-01-01" }, body: "# API token lifetime\n\nProduction API tokens expire after 60 minutes.\n" } },
+    claim_ids: ["clm_token"],
+    claim_decisions: [{ claim_id: "clm_token", disposition: "accepted", rationale: "explicit statement" }],
+    created_by: "kdlc-integrator/0.2.0"
+  }];
+
+  const submitted = await engine.execute("proposal", { proposal: { workflow_id: scaffold.workflow_id, task: "ingest", recording: template, normalized_evidence: evidence } });
+  assert.equal(submitted.proposals.length, 1);
+  assert.match(submitted.proposals[0].packet_hash, /^sha256:[a-f0-9]{64}$/);
+
+  const decision = await engine.execute("review", { proposal_id: "pr_token", decision: "approved", receipt_id: "rr_token" });
+  assert.equal(decision.receipt.decision, "approved");
+  assert.equal(decision.receipt.packet_hash, submitted.proposals[0].packet_hash);
+
+  const context = JSON.parse(await readFile(join(root, ".kdlc/governed/review-contexts", `${scaffold.workflow_id}.json`), "utf8")).context;
+  const current = {
+    concept: template.proposals[0].concept.after, target_revision: "rev-1",
+    source_hashes: [evidence.source_hash],
+    resolved_dependencies: context.resolved.dependencies, profile: context.resolved.profile, policies: context.resolved.policies
+  };
+  const publication = await engine.execute("publish", { proposal_id: "pr_token", receipt_id: "rr_token", current });
+  assert.equal(publication.intent.proposal_id, "pr_token");
+  assert.equal(publication.intent.packet_hash, submitted.proposals[0].packet_hash);
+});
+
+test("FEAT-030: the CLI accepts the scaffold flags and refuses malformed access", async () => {
+  const parsed = parseCli(["proposal", "--scaffold", "job_0123456789abcdef", "--access", "internal", "--license", "LicenseRef-Internal", "--workflow", "wf_custom1"]);
+  assert.deepEqual(parsed.input.scaffold, { job_id: "job_0123456789abcdef", access: "internal", license: "LicenseRef-Internal", workflow_id: "wf_custom1" });
+  const root = await mkdtemp(join(tmpdir(), "kdlc-scaffold-cli-"));
+  await new KdlcEngine({ root }).execute("init", { project_id: "scaffold.cli" });
+  const engine = createLocalProjectEngine({ root });
+  const job = await completedIngest(engine, root, "n.md", "# N\n\nA fact.\n");
+  await assert.rejects(engine.execute("proposal", { scaffold: { job_id: job.id, access: "secret", license: "L" } }), /--access <public\|internal\|restricted>/);
+  await assert.rejects(engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "LicenseRef-X", workflow_id: "wf-bad-hyphen" } }), /wf_<lowercase letters and digits>/);
+});


### PR DESCRIPTION
Closes #118

## Traceability

- Requirement IDs: FEAT-030
- Specification sections: §5.2, §7, §9.4

## Summary

Root-cause fix for the live k-test failure (conductor spun 7 minutes with zero engine activity): the recorded-proposal contract — normalized-evidence fixture, trusted review context with owner-declared access/rights, schema-valid recording with locator-anchored claims, profile-matching sensors/policies, and the publish current-context — was undiscoverable. Now:

- **`kdlc proposal --scaffold <ingest-job-id> --access <c> --license <l> [--workflow wf_x]`** — verifies the completed ingest job, refuses to default the governance decisions (access/license must be explicit), writes the trusted review-context record (with the base profile's required sensor whose check the runtime re-executes deterministically at submission, and the required policy binding), and emits a drafting kit: README playbook (fill → submit → review → publish with the exact current-context recipe), normalized-evidence.json, recording-template.json with correct hash bindings, and a locator menu. Conflicting workflow ids refuse rather than clobber.
- **Conductor prompt** gains the operational playbook (foreground, small batches, scaffold → fill → submit → stop at the gate, report packet hashes); **/kdlc:start** routes evidence-without-proposals to the scaffold path; **kdlc-proposal guidance** documents both modes.
- **Proven end to end in an automated test**: init → ingest → scaffold → fill per README → submit (packet hash) → review (receipt bound to packet) → publish (intent) — the full governed lifecycle on a live project, plus fail-closed tests for missing access/license, bad workflow ids, and scaffold collisions. Every schema/gate discovery from the live debugging session (wf_/clm_/pr_ id patterns, claim_ids/claim_decisions/created_by, sensor/policy profile matching, current-context) is encoded in the kit README so no future agent has to rediscover it.

No protected or pinned files; JSON envelope contract untouched.

## Verification

Commands and results:

```
$ npm test
tests 290 / pass 290 / fail 0   (new tests/governance/drafting-scaffold.test.mjs runs the full loop)

$ node packages/adapters/generate.mjs --check
(no output — no drift)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
