### PR TITLE
fix: governed refusals surface real codes and details (#121) [FEAT-031]

### DIFF
--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -14,5 +14,5 @@
   "tools": ["project_init", "project_get", "project_list_mounts", "kb_search", "kb_fetch", "kb_trace", "kb_conflicts", "kb_gaps", "source_excerpt", "job_status", "ingest_start", "proposal_create", "review_submit", "publish_request", "job_cancel"],
   "transports": ["stdio", "streamable-http"],
   "pending_requirements": [],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:9df4681b1207d7c4a404db3c21af0a4249b38929632893454f559bec087e0cc7"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:44aa79deee988f728ddffc83435077274c30b6656d7467cf5a2f6128d4bc5624"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -1025,6 +1025,23 @@
           "tests/governance/drafting-scaffold.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-031",
+      "title": "Governed refusals surface real codes and details through the envelope",
+      "issue": 121,
+      "specification_sections": [
+        "7.2"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "packages/cli/index.mjs"
+        ],
+        "tests": [
+          "tests/governance/cli-hints.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/packages/cli/index.mjs
+++ b/packages/cli/index.mjs
@@ -205,14 +205,25 @@ export class KdlcEngine {
         error: null,
       };
     } catch (error) {
+      // Governance and policy errors carry precise KDLC_ codes, messages, and
+      // details an agent can act on (which claim drifted, which schema field
+      // failed) — masking them as internal made every governed refusal look
+      // like a crash (FEAT-032 round, observed live). Only truly unknown
+      // errors stay scrubbed.
+      const coded =
+        typeof error?.code === "string" &&
+        error.code.startsWith("KDLC_") &&
+        ["GovernanceError", "AgentPolicyError"].includes(error?.name);
       const known =
         error instanceof EngineError
           ? error
-          : new EngineError(
-              "KDLC_INTERNAL",
-              "Internal operation failure",
-              EXIT.internal,
-            );
+          : coded
+            ? new EngineError(error.code, error.message, EXIT.policy, structuredClone(error.details ?? {}))
+            : new EngineError(
+                "KDLC_INTERNAL",
+                "Internal operation failure",
+                EXIT.internal,
+              );
       return {
         api_version: "kdlc.dev/engine-envelope/v1",
         ok: false,
@@ -891,11 +902,15 @@ export function renderEnvelope(envelope, output = "text") {
       return `${lines.join("\n")}\n`;
     }
     const framing = HUMAN_ERROR_FRAMING[envelope.error.class] ?? HUMAN_ERROR_FRAMING[EXIT.internal];
-    return `✖ ${envelope.operation} did not complete.\n  ${framing}\n  Detail: ${envelope.error.message} (${envelope.error.code})\n`;
+    const details = envelope.error.details && Object.keys(envelope.error.details).length > 0
+      ? `\n  Specifics: ${canonicalJson(envelope.error.details).slice(0, 2000)}`
+      : "";
+    return `✖ ${envelope.operation} did not complete.\n  ${framing}\n  Detail: ${envelope.error.message} (${envelope.error.code})${details}\n`;
   }
   if (envelope.ok)
     return `${envelope.operation}: ok\n${canonicalJson(envelope.result)}\n${hint ? `${hint}\n` : ""}`;
-  return `${envelope.operation}: ${envelope.error.code}: ${envelope.error.message}\n`;
+  const textDetails = envelope.error.details && Object.keys(envelope.error.details).length > 0 ? `\n${canonicalJson(envelope.error.details).slice(0, 2000)}` : "";
+  return `${envelope.operation}: ${envelope.error.code}: ${envelope.error.message}${textDetails}\n`;
 }
 
 export function createLocalProjectEngine(options = {}) {

--- a/packages/cli/index.mjs
+++ b/packages/cli/index.mjs
@@ -214,11 +214,25 @@ export class KdlcEngine {
         typeof error?.code === "string" &&
         error.code.startsWith("KDLC_") &&
         ["GovernanceError", "AgentPolicyError"].includes(error?.name);
+      // Exit classes are a stable §25 contract: conflicts and missing
+      // dependencies must not masquerade as policy refusals.
+      const codedClass = !coded
+        ? EXIT.internal
+        : /_(?:CONFLICT|IMMUTABLE)$/.test(error.code)
+          ? EXIT.conflict
+          : /_REQUIRED$/.test(error.code)
+            ? EXIT.dependency
+            : EXIT.policy;
+      // envelope() must never throw: details fall back to {} if uncloneable.
+      let codedDetails = {};
+      if (coded) {
+        try { codedDetails = JSON.parse(canonicalJson(error.details ?? {})); } catch { codedDetails = {}; }
+      }
       const known =
         error instanceof EngineError
           ? error
           : coded
-            ? new EngineError(error.code, error.message, EXIT.policy, structuredClone(error.details ?? {}))
+            ? new EngineError(error.code, error.message, codedClass, codedDetails)
             : new EngineError(
                 "KDLC_INTERNAL",
                 "Internal operation failure",

--- a/tests/governance/cli-hints.test.mjs
+++ b/tests/governance/cli-hints.test.mjs
@@ -77,3 +77,17 @@ test("FEAT-031: governed refusals surface their real code and details through th
   assert.equal(masked.error.code, "KDLC_INTERNAL");
   assert.ok(!JSON.stringify(masked).includes("secret internals"));
 });
+
+test("FEAT-031: coded refusals keep the exit-class taxonomy and never break the envelope", async () => {
+  const { GovernanceError } = await import("../../packages/governance/index.mjs");
+  const make = (code, extra = {}) => new KdlcEngine({ handlers: { status: () => { throw Object.assign(new GovernanceError(code, "m"), extra); } } });
+  assert.equal((await make("KDLC_DECISION_CONFLICT").envelope("status", {})).error.class, 4, "conflicts exit 4");
+  assert.equal((await make("KDLC_RECEIPT_IMMUTABLE").envelope("status", {})).error.class, 4, "immutability is a conflict");
+  assert.equal((await make("KDLC_GOVERNANCE_CONTROLS_REQUIRED").envelope("status", {})).error.class, 5, "missing controls are a dependency");
+  assert.equal((await make("KDLC_MODEL_RECORDING_INVALID").envelope("status", {})).error.class, 3, "refusals stay policy");
+  // Uncloneable details never break the envelope contract.
+  const hostile = await make("KDLC_MODEL_RECORDING_INVALID", { details: { fn: () => {} } }).envelope("status", {});
+  assert.equal(hostile.ok, false);
+  assert.equal(hostile.error.code, "KDLC_MODEL_RECORDING_INVALID");
+  assert.deepEqual(hostile.error.details, {});
+});

--- a/tests/governance/cli-hints.test.mjs
+++ b/tests/governance/cli-hints.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { renderEnvelope } from "../../packages/cli/index.mjs";
+import { KdlcEngine, renderEnvelope } from "../../packages/cli/index.mjs";
 
 const ingestEnvelope = {
   api_version: "kdlc.dev/engine-envelope/v1",
@@ -61,4 +61,19 @@ test("FEAT-028: claude-code setup prints the two-step marketplace install", asyn
   const install = instructions.find((line) => line.includes("claude plugin"));
   assert.match(install, /claude plugin marketplace add .+ && claude plugin install kdlc@kdlc/);
   assert.ok(!install.includes("claude plugin install /"), "no bare-path install instruction remains");
+});
+
+test("FEAT-031: governed refusals surface their real code and details through the envelope", async () => {
+  const { GovernanceError } = await import("../../packages/governance/index.mjs");
+  const engine = new KdlcEngine({ handlers: { status: () => { throw new GovernanceError("KDLC_MODEL_RECORDING_INVALID", "Recorded model output failed schema validation", { errors: [{ instancePath: "/claims/0/id" }] }); } } });
+  const envelope = await engine.envelope("status", {});
+  assert.equal(envelope.error.code, "KDLC_MODEL_RECORDING_INVALID");
+  assert.equal(envelope.error.details.errors[0].instancePath, "/claims/0/id");
+  assert.match(renderEnvelope(envelope, "human"), /Specifics: .*instancePath/);
+  assert.match(renderEnvelope(envelope, "text"), /KDLC_MODEL_RECORDING_INVALID: Recorded model output failed schema validation\n\{/);
+  // Unknown errors stay scrubbed.
+  const opaque = new KdlcEngine({ handlers: { status: () => { throw new Error("secret internals: /etc/passwd"); } } });
+  const masked = await opaque.envelope("status", {});
+  assert.equal(masked.error.code, "KDLC_INTERNAL");
+  assert.ok(!JSON.stringify(masked).includes("secret internals"));
 });


### PR DESCRIPTION
Closes #121

## Traceability

- Requirement IDs: FEAT-031
- Specification sections: §7.2

## Summary

Observed live twice (the k-test drafting assistant literally said "the engine swallows the real exception"; the FEAT-030 development session had to bypass the envelope for the same reason): GovernanceError/AgentPolicyError refusals carry precise `KDLC_*` codes and actionable details — the exact schema violations, which claim drifted — but the envelope masked every one as `KDLC_INTERNAL: Internal operation failure`, leaving agents to guess-and-retry blind.

- The envelope now passes through errors that are explicitly `GovernanceError`/`AgentPolicyError` with `KDLC_`-prefixed codes (policy exit class, details structuredCloned); **truly unknown errors remain scrubbed** — test-asserted that internals never leak.
- text/human rendering appends a truncated `Specifics:` line with the details, so both humans and agents can self-correct in one step (live-verified: a bad claim id now shows the exact `instancePath` and pattern instead of "Internal operation failure").
- JSON envelope shape unchanged (`error.details` always existed; it now carries content for coded refusals).

No protected or pinned files.

## Verification

Commands and results:

```
$ npm test
tests 291 / pass 291 / fail 0

$ kdlc proposal '<recording with bad claim id>' --output human
  Detail: Recorded model output failed schema validation (KDLC_MODEL_RECORDING_INVALID)
  Specifics: {"errors":[{"instancePath":"/claims/0/id","keyword":"pattern",...}]}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
