### PR TITLE
feat: token-efficient drafting (#123) [FEAT-032]

### DIFF
--- a/distribution/claude-code/agents/conductor.md
+++ b/distribution/claude-code/agents/conductor.md
@@ -24,6 +24,8 @@ background work — and use only the governed engine operations:
 1. **Scaffold**: from a completed ingest job, run the `proposal` operation
    with `--scaffold <job-id> --access <classification> --license <license>`
    (ask the human for access and license — they are governance decisions).
+   For multi-document jobs add `--source <n>` or `--all-sources`; for a
+   large document add `--units <start>-<end>` and draft section by section.
    This writes a drafting kit under `.kdlc/drafting/<workflow>/` with a
    README, the normalized evidence, a locator menu, and a recording template
    whose hashes the runtime will accept.
@@ -33,9 +35,9 @@ background work — and use only the governed engine operations:
    proposals carry claim_ids, claim_decisions, and created_by. For a large
    source, draft a few concepts from one section first; expand after the
    first review round.
-3. **Submit**: call the `proposal` operation with the filled recording and
-   the kit's normalized evidence (the exact JSON shape is in the README).
-   Report each returned packet hash to the human.
+3. **Submit**: run `proposal --submit <workflow-id>` — the engine reads
+   the kit files from disk, so never paste evidence or the recording into
+   the conversation. Report each returned packet hash to the human.
 4. **Stop at the gate**: the human decides via `review`; publication goes
    through `publish` with the current-context JSON the kit README
    describes. Never infer a decision from conversation.

--- a/distribution/claude-code/commands/kdlc-proposal.md
+++ b/distribution/claude-code/commands/kdlc-proposal.md
@@ -5,7 +5,7 @@ argument-hint: JSON string array
 
 **When to use:** Evidence is ingested and you want it drafted into reviewable knowledge — or you want to submit a filled drafting kit.
 
-**What you give it:** To begin: --scaffold <ingest-job-id> --access <public|internal|restricted> --license <license>. To submit: the filled recording per the kit README.
+**What you give it:** To begin: --scaffold <ingest-job-id> --access <public|internal|restricted> --license <license> (add --source <n>/--all-sources for multi-document jobs, --units a-b to slice a large document). To submit a filled kit: --submit <workflow-id>.
 
 **What you get back:** A drafting kit (scaffold), or review packets with hashes (submit) — proposals only become knowledge after review.
 

--- a/distribution/codex/.codex/agents/conductor.md
+++ b/distribution/codex/.codex/agents/conductor.md
@@ -24,6 +24,8 @@ background work — and use only the governed engine operations:
 1. **Scaffold**: from a completed ingest job, run the `proposal` operation
    with `--scaffold <job-id> --access <classification> --license <license>`
    (ask the human for access and license — they are governance decisions).
+   For multi-document jobs add `--source <n>` or `--all-sources`; for a
+   large document add `--units <start>-<end>` and draft section by section.
    This writes a drafting kit under `.kdlc/drafting/<workflow>/` with a
    README, the normalized evidence, a locator menu, and a recording template
    whose hashes the runtime will accept.
@@ -33,9 +35,9 @@ background work — and use only the governed engine operations:
    proposals carry claim_ids, claim_decisions, and created_by. For a large
    source, draft a few concepts from one section first; expand after the
    first review round.
-3. **Submit**: call the `proposal` operation with the filled recording and
-   the kit's normalized evidence (the exact JSON shape is in the README).
-   Report each returned packet hash to the human.
+3. **Submit**: run `proposal --submit <workflow-id>` — the engine reads
+   the kit files from disk, so never paste evidence or the recording into
+   the conversation. Report each returned packet hash to the human.
 4. **Stop at the gate**: the human decides via `review`; publication goes
    through `publish` with the current-context JSON the kit README
    describes. Never infer a decision from conversation.

--- a/distribution/codex/.codex/agents/conductor.toml
+++ b/distribution/codex/.codex/agents/conductor.toml
@@ -22,6 +22,8 @@ background work — and use only the governed engine operations:
 1. **Scaffold**: from a completed ingest job, run the `proposal` operation
    with `--scaffold <job-id> --access <classification> --license <license>`
    (ask the human for access and license — they are governance decisions).
+   For multi-document jobs add `--source <n>` or `--all-sources`; for a
+   large document add `--units <start>-<end>` and draft section by section.
    This writes a drafting kit under `.kdlc/drafting/<workflow>/` with a
    README, the normalized evidence, a locator menu, and a recording template
    whose hashes the runtime will accept.
@@ -31,9 +33,9 @@ background work — and use only the governed engine operations:
    proposals carry claim_ids, claim_decisions, and created_by. For a large
    source, draft a few concepts from one section first; expand after the
    first review round.
-3. **Submit**: call the `proposal` operation with the filled recording and
-   the kit's normalized evidence (the exact JSON shape is in the README).
-   Report each returned packet hash to the human.
+3. **Submit**: run `proposal --submit <workflow-id>` — the engine reads
+   the kit files from disk, so never paste evidence or the recording into
+   the conversation. Report each returned packet hash to the human.
 4. **Stop at the gate**: the human decides via `review`; publication goes
    through `publish` with the current-context JSON the kit README
    describes. Never infer a decision from conversation.

--- a/distribution/kiro-ide/.kiro/agents/conductor.md
+++ b/distribution/kiro-ide/.kiro/agents/conductor.md
@@ -19,6 +19,8 @@ background work — and use only the governed engine operations:
 1. **Scaffold**: from a completed ingest job, run the `proposal` operation
    with `--scaffold <job-id> --access <classification> --license <license>`
    (ask the human for access and license — they are governance decisions).
+   For multi-document jobs add `--source <n>` or `--all-sources`; for a
+   large document add `--units <start>-<end>` and draft section by section.
    This writes a drafting kit under `.kdlc/drafting/<workflow>/` with a
    README, the normalized evidence, a locator menu, and a recording template
    whose hashes the runtime will accept.
@@ -28,9 +30,9 @@ background work — and use only the governed engine operations:
    proposals carry claim_ids, claim_decisions, and created_by. For a large
    source, draft a few concepts from one section first; expand after the
    first review round.
-3. **Submit**: call the `proposal` operation with the filled recording and
-   the kit's normalized evidence (the exact JSON shape is in the README).
-   Report each returned packet hash to the human.
+3. **Submit**: run `proposal --submit <workflow-id>` — the engine reads
+   the kit files from disk, so never paste evidence or the recording into
+   the conversation. Report each returned packet hash to the human.
 4. **Stop at the gate**: the human decides via `review`; publication goes
    through `publish` with the current-context JSON the kit README
    describes. Never infer a decision from conversation.

--- a/distribution/kiro-ide/.kiro/skills/kdlc-proposal/SKILL.md
+++ b/distribution/kiro-ide/.kiro/skills/kdlc-proposal/SKILL.md
@@ -6,7 +6,7 @@ user-invocable: true
 
 **When to use:** Evidence is ingested and you want it drafted into reviewable knowledge — or you want to submit a filled drafting kit.
 
-**What you give it:** To begin: --scaffold <ingest-job-id> --access <public|internal|restricted> --license <license>. To submit: the filled recording per the kit README.
+**What you give it:** To begin: --scaffold <ingest-job-id> --access <public|internal|restricted> --license <license> (add --source <n>/--all-sources for multi-document jobs, --units a-b to slice a large document). To submit a filled kit: --submit <workflow-id>.
 
 **What you get back:** A drafting kit (scaffold), or review packets with hashes (submit) — proposals only become knowledge after review.
 

--- a/distribution/kiro/.kiro/agents/conductor.md
+++ b/distribution/kiro/.kiro/agents/conductor.md
@@ -19,6 +19,8 @@ background work — and use only the governed engine operations:
 1. **Scaffold**: from a completed ingest job, run the `proposal` operation
    with `--scaffold <job-id> --access <classification> --license <license>`
    (ask the human for access and license — they are governance decisions).
+   For multi-document jobs add `--source <n>` or `--all-sources`; for a
+   large document add `--units <start>-<end>` and draft section by section.
    This writes a drafting kit under `.kdlc/drafting/<workflow>/` with a
    README, the normalized evidence, a locator menu, and a recording template
    whose hashes the runtime will accept.
@@ -28,9 +30,9 @@ background work — and use only the governed engine operations:
    proposals carry claim_ids, claim_decisions, and created_by. For a large
    source, draft a few concepts from one section first; expand after the
    first review round.
-3. **Submit**: call the `proposal` operation with the filled recording and
-   the kit's normalized evidence (the exact JSON shape is in the README).
-   Report each returned packet hash to the human.
+3. **Submit**: run `proposal --submit <workflow-id>` — the engine reads
+   the kit files from disk, so never paste evidence or the recording into
+   the conversation. Report each returned packet hash to the human.
 4. **Stop at the gate**: the human decides via `review`; publication goes
    through `publish` with the current-context JSON the kit README
    describes. Never infer a decision from conversation.

--- a/distribution/kiro/.kiro/skills/kdlc-proposal/SKILL.md
+++ b/distribution/kiro/.kiro/skills/kdlc-proposal/SKILL.md
@@ -6,7 +6,7 @@ user-invocable: true
 
 **When to use:** Evidence is ingested and you want it drafted into reviewable knowledge — or you want to submit a filled drafting kit.
 
-**What you give it:** To begin: --scaffold <ingest-job-id> --access <public|internal|restricted> --license <license>. To submit: the filled recording per the kit README.
+**What you give it:** To begin: --scaffold <ingest-job-id> --access <public|internal|restricted> --license <license> (add --source <n>/--all-sources for multi-document jobs, --units a-b to slice a large document). To submit a filled kit: --submit <workflow-id>.
 
 **What you get back:** A drafting kit (scaffold), or review packets with hashes (submit) — proposals only become knowledge after review.
 

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -14,5 +14,5 @@
   "tools": ["project_init", "project_get", "project_list_mounts", "kb_search", "kb_fetch", "kb_trace", "kb_conflicts", "kb_gaps", "source_excerpt", "job_status", "ingest_start", "proposal_create", "review_submit", "publish_request", "job_cancel"],
   "transports": ["stdio", "streamable-http"],
   "pending_requirements": [],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:44aa79deee988f728ddffc83435077274c30b6656d7467cf5a2f6128d4bc5624"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:a541b3ee94251c635333214fa6af5fc7417a6095b6e15b1e76e674f550ba9b48"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -1042,6 +1042,26 @@
           "tests/governance/cli-hints.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-032",
+      "title": "Token-efficient drafting: submit-from-kit, per-source scaffolds, unit slicing, quiet echoes",
+      "issue": 123,
+      "specification_sections": [
+        "5.2",
+        "7.2"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "packages/cli/index.mjs",
+          "packages/agents/definitions/index.mjs",
+          "packages/adapters/generate.mjs"
+        ],
+        "tests": [
+          "tests/governance/drafting-scaffold.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/packages/adapters/generate.mjs
+++ b/packages/adapters/generate.mjs
@@ -47,7 +47,7 @@ const COMMAND_GUIDANCE = {
   },
   proposal: {
     when: "Evidence is ingested and you want it drafted into reviewable knowledge — or you want to submit a filled drafting kit.",
-    give: "To begin: --scaffold <ingest-job-id> --access <public|internal|restricted> --license <license>. To submit: the filled recording per the kit README.",
+    give: "To begin: --scaffold <ingest-job-id> --access <public|internal|restricted> --license <license> (add --source <n>/--all-sources for multi-document jobs, --units a-b to slice a large document). To submit a filled kit: --submit <workflow-id>.",
     get: "A drafting kit (scaffold), or review packets with hashes (submit) — proposals only become knowledge after review.",
     next: "Fill the kit per its README, submit, then kdlc review for the decision.",
   },

--- a/packages/agents/definitions/index.mjs
+++ b/packages/agents/definitions/index.mjs
@@ -52,6 +52,8 @@ background work — and use only the governed engine operations:
 1. **Scaffold**: from a completed ingest job, run the \`proposal\` operation
    with \`--scaffold <job-id> --access <classification> --license <license>\`
    (ask the human for access and license — they are governance decisions).
+   For multi-document jobs add \`--source <n>\` or \`--all-sources\`; for a
+   large document add \`--units <start>-<end>\` and draft section by section.
    This writes a drafting kit under \`.kdlc/drafting/<workflow>/\` with a
    README, the normalized evidence, a locator menu, and a recording template
    whose hashes the runtime will accept.
@@ -61,9 +63,9 @@ background work — and use only the governed engine operations:
    proposals carry claim_ids, claim_decisions, and created_by. For a large
    source, draft a few concepts from one section first; expand after the
    first review round.
-3. **Submit**: call the \`proposal\` operation with the filled recording and
-   the kit's normalized evidence (the exact JSON shape is in the README).
-   Report each returned packet hash to the human.
+3. **Submit**: run \`proposal --submit <workflow-id>\` — the engine reads
+   the kit files from disk, so never paste evidence or the recording into
+   the conversation. Report each returned packet hash to the human.
 4. **Stop at the gate**: the human decides via \`review\`; publication goes
    through \`publish\` with the current-context JSON the kit README
    describes. Never infer a decision from conversation.`,

--- a/packages/cli/index.mjs
+++ b/packages/cli/index.mjs
@@ -842,17 +842,24 @@ export function parseCli(argv) {
     [input.proposal_id, input.receipt_id] = positionals;
     if (positionals[2]) input.current = JSON.parse(positionals[2]);
   }
-  if (operation === "proposal" && positionals.includes("--scaffold")) {
+  if (operation === "proposal" && (positionals.includes("--scaffold") || positionals.includes("--submit"))) {
     const flag = (name) => {
       const index = positionals.indexOf(name);
       return index === -1 ? undefined : positionals[index + 1];
     };
-    input.scaffold = {
-      job_id: flag("--scaffold"),
-      access: flag("--access"),
-      license: flag("--license"),
-      ...(flag("--workflow") ? { workflow_id: flag("--workflow") } : {}),
-    };
+    if (positionals.includes("--submit")) {
+      input.submit = { workflow_id: flag("--submit") };
+    } else {
+      input.scaffold = {
+        job_id: flag("--scaffold"),
+        access: flag("--access"),
+        license: flag("--license"),
+        ...(flag("--workflow") ? { workflow_id: flag("--workflow") } : {}),
+        ...(flag("--source") !== undefined ? { source: flag("--source") } : {}),
+        ...(positionals.includes("--all-sources") ? { all_sources: true } : {}),
+        ...(flag("--units") ? { units: flag("--units") } : {}),
+      };
+    }
     input.args = [];
     return { operation, input, output };
   }
@@ -899,8 +906,26 @@ function guidanceHint(envelope) {
   return null;
 }
 
+// FEAT-032 (#123): human/text output never carries evidence unit bodies — a
+// single document was transiting agent context repeatedly via job echoes.
+// The JSON envelope (machine contract) is untouched.
+function elideUnits(value, depth = 0) {
+  if (depth > 6 || value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map((item) => elideUnits(item, depth + 1));
+  const out = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if ((key === "units" || key === "probabilisticUnits") && Array.isArray(entry)) {
+      out[key] = `[${entry.length} unit${entry.length === 1 ? "" : "s"} elided — kdlc proposal --scaffold to draft from them, source_excerpt to inspect one]`;
+    } else {
+      out[key] = elideUnits(entry, depth + 1);
+    }
+  }
+  return out;
+}
+
 export function renderEnvelope(envelope, output = "text") {
   if (output === "json") return `${canonicalJson(envelope)}\n`;
+  envelope = envelope.ok && envelope.result ? { ...envelope, result: elideUnits(envelope.result) } : envelope;
   const hint = guidanceHint(envelope);
   if (output === "human") {
     if (envelope.ok) {
@@ -1221,7 +1246,7 @@ export function createLocalProjectEngine(options = {}) {
   // completed ingest job into (a) a trusted review context — with the access
   // classification and license the OWNER explicitly declares, never a silent
   // default — and (b) a drafting kit whose hashes the runtime will accept.
-  const scaffoldProposalDrafting = async ({ job_id: jobId, access, license, workflow_id: requestedWorkflow }) => {
+  const scaffoldProposalDrafting = async ({ job_id: jobId, access, license, workflow_id: requestedWorkflow, source, all_sources: allSources, units: unitRange }) => {
     if (typeof jobId !== "string" || !/^job_[a-f0-9]{16}$/.test(jobId)) throw inputError("scaffold requires the completed ingest job id (job_<16 hex>)");
     if (!["public", "internal", "restricted"].includes(access)) {
       throw inputError("scaffold requires --access <public|internal|restricted> — the source's access classification is a governance decision only you can make");
@@ -1233,13 +1258,45 @@ export function createLocalProjectEngine(options = {}) {
     if (!existsSync(jobPath)) throw missing("Requested job is unavailable");
     const job = JSON.parse(readFileSync(jobPath, "utf8"));
     if (job.operation !== "ingest" || job.state !== "completed") throw inputError(`scaffold needs a completed ingest job; ${jobId} is ${job.operation}/${job.state}`);
-    const artifact = job.result?.normalized?.[0];
-    if (!artifact?.manifest || artifact.manifest.status !== "complete") throw inputError("the job's normalization did not complete — nothing to draft from");
-    const workflowId = requestedWorkflow ?? `wf_${jobId.slice(4)}`;
-    if (!/^wf_[a-z0-9]+$/.test(workflowId)) throw inputError("workflow_id must match wf_<lowercase letters and digits> (the concept-proposal schema enforces it)");
-    const units = artifact.units.filter((unit) => typeof unit.text === "string" && unit.text.trim().length > 0)
+    const artifacts = (job.result?.normalized ?? []).filter((entry) => entry?.manifest?.status === "complete");
+    if (artifacts.length === 0) throw inputError("the job's normalization did not complete — nothing to draft from");
+    // Fail closed on multi-document jobs: silently drafting only the first
+    // file loses the rest. Each document gets its own workflow and kit.
+    let selection;
+    if (allSources) {
+      if (requestedWorkflow) throw inputError("--workflow cannot combine with --all-sources (each document gets its own workflow)");
+      selection = artifacts.map((artifact, index) => ({ artifact, index }));
+    } else if (source !== undefined) {
+      const index = Number(source);
+      if (!Number.isInteger(index) || index < 0 || index >= artifacts.length) throw inputError(`--source must be 0..${artifacts.length - 1} for this job`);
+      selection = [{ artifact: artifacts[index], index }];
+    } else if (artifacts.length === 1) {
+      selection = [{ artifact: artifacts[0], index: 0 }];
+    } else {
+      const menu = artifacts.map((artifact, index) => `${index}: ${job.request?.sources?.[index] ?? artifact.manifest.source_id} (${artifact.units.length} units)`).join("; ");
+      throw inputError(`this job ingested ${artifacts.length} documents — pick one with --source <n> or scaffold every document with --all-sources. Sources: ${menu}`);
+    }
+    let sliceBounds = null;
+    if (unitRange !== undefined) {
+      const match = /^([0-9]+)-([0-9]+)$/.exec(String(unitRange));
+      if (!match) throw inputError("--units must be <start>-<end> (1-based positions among the document's text units)");
+      sliceBounds = [Number(match[1]), Number(match[2])];
+      if (sliceBounds[0] < 1 || sliceBounds[1] < sliceBounds[0]) throw inputError("--units range must satisfy 1 <= start <= end");
+    }
+    const scaffolded = [];
+    for (const { artifact, index } of selection) {
+      const workflowId = requestedWorkflow ?? (selection.length > 1 || source !== undefined ? `wf_${jobId.slice(4)}s${index}` : `wf_${jobId.slice(4)}`);
+      if (!/^wf_[a-z0-9]+$/.test(workflowId)) throw inputError("workflow_id must match wf_<lowercase letters and digits> (the concept-proposal schema enforces it)");
+      scaffolded.push(await scaffoldOneSource({ artifact, workflowId, access, license, sliceBounds, sourceName: job.request?.sources?.[index] ?? artifact.manifest.source_id }));
+    }
+    return selection.length === 1 ? scaffolded[0] : { job_id: jobId, scaffolds: scaffolded, next: "fill each kit's recording template, then submit each with kdlc proposal --submit <workflow-id>" };
+  };
+  const scaffoldOneSource = async ({ artifact, workflowId, access, license, sliceBounds, sourceName }) => {
+    let units = artifact.units.filter((unit) => typeof unit.text === "string" && unit.text.trim().length > 0)
       .map((unit) => ({ locator: unit.locator, text: unit.text }));
-    if (units.length === 0) throw inputError("the ingested source produced no text units to draft from");
+    const totalUnits = units.length;
+    if (sliceBounds) units = units.slice(sliceBounds[0] - 1, sliceBounds[1]);
+    if (units.length === 0) throw inputError(sliceBounds ? `--units ${sliceBounds[0]}-${sliceBounds[1]} selects nothing (the document has ${totalUnits} text units)` : "the ingested source produced no text units to draft from");
     const normalizedEvidence = {
       api_version: "kdlc.dev/recorded-normalized-fixture/v1alpha1",
       source_id: artifact.manifest.source_id,
@@ -1310,7 +1367,10 @@ export function createLocalProjectEngine(options = {}) {
       "3. Set model.model and model.prompt to what actually drafted the content.",
       "4. Submit:",
       "",
-      "   kdlc proposal '{\"proposal\":{\"workflow_id\":\"" + workflowId + "\",\"task\":\"ingest\",\"recording\":<recording-template.json contents>,\"normalized_evidence\":<normalized-evidence.json contents>}}'",
+      "   kdlc proposal --submit " + workflowId,
+      "",
+      "   (the engine reads this kit's recording-template.json and normalized-evidence.json from disk —",
+      "   never paste their contents into the conversation).",
       "",
       "   (or pass the same object through the harness runner). The response carries each proposal's review",
       "   packet and packet hash — bring that to the human for the review decision.",
@@ -1324,13 +1384,36 @@ export function createLocalProjectEngine(options = {}) {
     ].join("\n"));
     return {
       workflow_id: workflowId,
+      source: sourceName,
       review_context: contextRecordPath,
       kit: [".kdlc/drafting/" + workflowId + "/README.md", ".kdlc/drafting/" + workflowId + "/recording-template.json", ".kdlc/drafting/" + workflowId + "/normalized-evidence.json", ".kdlc/drafting/" + workflowId + "/locators.json"],
       units: units.length,
+      ...(sliceBounds ? { slice: `${sliceBounds[0]}-${sliceBounds[1]} of ${totalUnits} text units` } : {}),
       access: { classification: access },
       rights,
-      next: "fill the recording template (see the kit README), then submit it with kdlc proposal",
+      next: "fill the recording template (see the kit README), then submit with kdlc proposal --submit " + workflowId,
     };
+  };
+  // FEAT-032 (#123): submit from the kit on disk — evidence and recording
+  // never transit the model context; the agent only edits the template file.
+  const submitProposalFromKit = async ({ workflow_id: workflowId }) => {
+    if (typeof workflowId !== "string" || !/^wf_[a-z0-9]+$/.test(workflowId)) throw inputError("--submit requires the scaffolded workflow id (wf_...)");
+    const kitDirectory = resolve(root, ".kdlc/drafting", workflowId);
+    const read = (name) => {
+      const path = resolve(kitDirectory, name);
+      if (!existsSync(path)) throw missing(`the drafting kit for ${workflowId} is missing ${name} — run kdlc proposal --scaffold first`);
+      try { return JSON.parse(readFileSync(path, "utf8")); }
+      catch { throw inputError(`${name} in the ${workflowId} kit is not valid JSON — fix the file and retry`); }
+    };
+    const recording = read("recording-template.json");
+    const normalizedEvidence = read("normalized-evidence.json");
+    if (!Array.isArray(recording.claims) || recording.claims.length === 0 || !Array.isArray(recording.proposals) || recording.proposals.length === 0) {
+      throw inputError(`the recording template for ${workflowId} has empty claims or proposals — fill it per the kit README before submitting`);
+    }
+    if (typeof recording.model?.model === "string" && recording.model.model.startsWith("FILL:")) {
+      throw inputError("set model.model and model.prompt in the recording template to what actually drafted the content");
+    }
+    return governed.proposal_create({ proposal: { workflow_id: workflowId, task: recording.task ?? "ingest", recording, normalized_evidence: normalizedEvidence } });
   };
   const handlers = policy
     ? {
@@ -1344,7 +1427,9 @@ export function createLocalProjectEngine(options = {}) {
               proposal: async (input, extras) =>
                 input.scaffold
                   ? scaffoldProposalDrafting(input.scaffold)
-                  : governed.proposal_create(input, extras),
+                  : input.submit
+                    ? submitProposalFromKit(input.submit)
+                    : governed.proposal_create(input, extras),
             }
           : {}),
         ...(governed.review_submit ? { review: governed.review_submit } : {}),

--- a/tests/governance/drafting-scaffold.test.mjs
+++ b/tests/governance/drafting-scaffold.test.mjs
@@ -93,3 +93,64 @@ test("FEAT-030: the CLI accepts the scaffold flags and refuses malformed access"
   await assert.rejects(engine.execute("proposal", { scaffold: { job_id: job.id, access: "secret", license: "L" } }), /--access <public\|internal\|restricted>/);
   await assert.rejects(engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "LicenseRef-X", workflow_id: "wf-bad-hyphen" } }), /wf_<lowercase letters and digits>/);
 });
+
+test("FEAT-032: submit-from-kit runs the loop without inline evidence; unfilled kits refuse helpfully", async () => {
+  const root = await mkdtemp(join(tmpdir(), "kdlc-kit-submit-"));
+  await new KdlcEngine({ root }).execute("init", { project_id: "kit.submit" });
+  const engine = createLocalProjectEngine({ root });
+  const job = await completedIngest(engine, root, "spec.md", "# Spec\n\n## Token lifetime\n\nProduction API tokens expire after 60 minutes.\n");
+  const scaffold = await engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "LicenseRef-Internal" } });
+  await assert.rejects(engine.execute("proposal", { submit: { workflow_id: scaffold.workflow_id } }), /empty claims or proposals — fill it/);
+  await assert.rejects(engine.execute("proposal", { submit: { workflow_id: "wf_nokit" } }), /missing recording-template\.json/);
+
+  const kit = join(root, ".kdlc/drafting", scaffold.workflow_id);
+  const evidence = JSON.parse(await readFile(join(kit, "normalized-evidence.json"), "utf8"));
+  const template = JSON.parse(await readFile(join(kit, "recording-template.json"), "utf8"));
+  const unit = evidence.units.find(({ text }) => /expire/.test(text));
+  const rights = { license: "LicenseRef-Internal", redistribution: "prohibited", derivative_use: "allowed", commercial_use: "prohibited" };
+  template.model = { provider: "recorded", model: "test-model", prompt: "kit-submit", recorded_at: template.model.recorded_at };
+  template.claims = [{ id: "clm_kit", text: unit.text, source_id: evidence.source_id, source_hash: evidence.source_hash, locator: unit.locator, extraction: "explicit", status: "accepted", access: { classification: "internal" }, rights }];
+  template.proposals = [{ api_version: "kdlc.dev/concept-proposal/v1alpha1", id: "pr_kit", workflow_id: scaffold.workflow_id, task: "ingest", state: "review_pending", target: { knowledge_base_id: "local.kit.submit", revision: "rev-1", subject: "kb://local.kit.submit/policies/tokens" }, concept: { before: null, after: { frontmatter: { type: "Policy", title: "Tokens", description: "d", status: "stable", generated: { by: "kdlc-integrator/0.2.0", at: "2026-08-16T20:30:00Z" }, sources: [{ id: "spec", source_hash: evidence.source_hash }], stale_after: "2030-01-01" }, body: "# T\n\nx\n" } }, claim_ids: ["clm_kit"], claim_decisions: [{ claim_id: "clm_kit", disposition: "accepted", rationale: "explicit" }], created_by: "kdlc-integrator/0.2.0" }];
+  await writeFile(join(kit, "recording-template.json"), JSON.stringify(template));
+  const submitted = await engine.execute("proposal", { submit: { workflow_id: scaffold.workflow_id } });
+  assert.match(submitted.proposals[0].packet_hash, /^sha256:[a-f0-9]{64}$/);
+});
+
+test("FEAT-032: multi-document jobs scaffold per source, never silently first-only", async () => {
+  const root = await mkdtemp(join(tmpdir(), "kdlc-multi-"));
+  await new KdlcEngine({ root }).execute("init", { project_id: "multi.fixture" });
+  const engine = createLocalProjectEngine({ root });
+  await writeFile(join(root, "a.md"), "# A\n\nFact A.\n");
+  await writeFile(join(root, "b.md"), "# B\n\nFact B.\n");
+  const started = await engine.execute("ingest_start", { sources: ["a.md", "b.md"], idempotency_key: "multi-1" });
+  let job = started;
+  for (let attempt = 0; attempt < 100 && !["completed", "failed"].includes(job.state); attempt += 1) {
+    await new Promise((r) => setTimeout(r, 50));
+    job = await engine.execute("job_status", { id: started.id });
+  }
+  assert.equal(job.state, "completed");
+  await assert.rejects(engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "L" } }), /ingested 2 documents — pick one with --source <n> or scaffold every document with --all-sources/);
+  const all = await engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "LicenseRef-Internal", all_sources: true } });
+  assert.equal(all.scaffolds.length, 2);
+  assert.notEqual(all.scaffolds[0].workflow_id, all.scaffolds[1].workflow_id);
+  assert.deepEqual(all.scaffolds.map(({ source }) => source), ["a.md", "b.md"]);
+});
+
+test("FEAT-032: unit slicing drafts a section whose anchors still verify; text output elides unit bodies", async () => {
+  const root = await mkdtemp(join(tmpdir(), "kdlc-slice-"));
+  await new KdlcEngine({ root }).execute("init", { project_id: "slice.fixture" });
+  const engine = createLocalProjectEngine({ root });
+  const job = await completedIngest(engine, root, "spec.md", "# Spec\n\n## One\n\nFirst fact.\n\n## Two\n\nSecond fact.\n\n## Three\n\nThird fact.\n");
+  const sliced = await engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "LicenseRef-Internal", units: "2-3" } });
+  assert.equal(sliced.units, 2);
+  assert.match(sliced.slice, /^2-3 of \d+ text units$/);
+  await assert.rejects(engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "L", workflow_id: "wf_slicebad", units: "9-4" } }), /--units range/);
+
+  const { renderEnvelope } = await import("../../packages/cli/index.mjs");
+  const envelope = await engine.envelope("job_status", { id: job.id });
+  const text = renderEnvelope(envelope, "text");
+  assert.ok(!text.includes("First fact."), "unit bodies never appear in text output");
+  assert.match(text, /units elided/);
+  const json = renderEnvelope(envelope, "json");
+  assert.ok(json.includes("First fact."), "JSON envelope keeps full fidelity");
+});


### PR DESCRIPTION
Closes #123

## Traceability

- Requirement IDs: FEAT-032
- Specification sections: §5.2, §7.2

## Summary

Live k-test finding: one document cost 100k+ tokens because its content transited the agent's context 4–5 times (job echoes, kit duplication, inline-evidence submit). Fixes:

- **`kdlc proposal --submit <workflow>`** — the engine reads the filled `recording-template.json` and `normalized-evidence.json` from the kit on disk; evidence never passes through the model. Helpful refusals for missing kits, invalid JSON, unfilled templates, and FILL: placeholders. The kit README, conductor playbook, and command guidance all switch to this flow.
- **Per-source scaffolds** — a multi-document ingest job now **fails closed** with a source menu instead of silently drafting only the first file (a real bug your folder question exposed); `--source <n>` picks one, `--all-sources` emits one kit + workflow per document (each document keeps its own access/license declaration).
- **`--units <start>-<end>`** — slices a large document so drafting proceeds section by section; the sliced fixture's hashes and anchors still verify.
- **Quiet echoes** — text/human rendering of any result elides evidence unit bodies (`[N units elided — …]` with counts and pointers); the **JSON envelope is untouched** (test-asserted both ways).

## Verification

Commands and results:

```
$ npm test
tests 295 / pass 295 / fail 0   (3 new FEAT-032 tests incl. a no-inline-evidence full loop and the multi-doc fail-closed path)

$ node packages/adapters/generate.mjs --check
(no output — no drift)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
