### PR TITLE
feat: publish last mile — atomic landing and the human gate (#125) [FEAT-033]

### DIFF
--- a/distribution/claude-code/agents/conductor.md
+++ b/distribution/claude-code/agents/conductor.md
@@ -38,9 +38,10 @@ background work — and use only the governed engine operations:
 3. **Submit**: run `proposal --submit <workflow-id>` — the engine reads
    the kit files from disk, so never paste evidence or the recording into
    the conversation. Report each returned packet hash to the human.
-4. **Stop at the gate**: the human decides via `review`; publication goes
-   through `publish` with the current-context JSON the kit README
-   describes. Never infer a decision from conversation.
+4. **Stop at the gate**: run `publish` bare to show the human what awaits
+   them; their decision is `publish <proposal-id> --approve|--reject` —
+   approval lands the concept atomically and query answers immediately.
+   Never infer a decision from conversation.
 
 ## When to use this agent
 

--- a/distribution/claude-code/commands/kdlc-publish.md
+++ b/distribution/claude-code/commands/kdlc-publish.md
@@ -3,11 +3,11 @@ description: Run the governed K-DLC publish operation
 argument-hint: JSON string array
 ---
 
-**When to use:** Approved knowledge should become visible at its access level.
+**When to use:** You want to see what's waiting on your decision, or decide it — this is the human gate.
 
-**What you give it:** The approved item to publish.
+**What you give it:** Nothing to list pending review packets; or <proposal-id> --approve "reason" (or --reject / --request-changes) to decide and land it in one step.
 
-**What you get back:** Published, versioned knowledge — refused if approvals are missing.
+**What you get back:** On approval: the concept file, index, and retrieval catalog updated atomically — kdlc query answers with citations immediately. Refusals and rejections change nothing.
 
 **Usually next:** kdlc query to see it live; kdlc status for the audit trail.
 

--- a/distribution/claude-code/commands/kdlc-start.md
+++ b/distribution/claude-code/commands/kdlc-start.md
@@ -21,9 +21,10 @@ Follow this routine (read-only assessment first — never mutate while assessing
      user for --access and --license — governance decisions), then follow the
      kit README under `.kdlc/drafting/<workflow>/` to draft and submit.
      Work in the foreground and report the returned packet hashes.
-   - Proposals pending review → present the review packet and its hash; the
-     user's decision goes through the governed `review` operation.
-   - Approved but unpublished → offer `publish`.
+   - Proposals pending review → run `publish` bare to list them, present
+     each packet and hash, and record the user's decision with
+     `publish <proposal-id> --approve|--reject|--request-changes` — on
+     approval the concept lands atomically and query answers immediately.
    - Published knowledge present → offer `query`, `refresh`, or `gaps`.
    - Remote connectors configured but not ready → point at the
      connector-setup agent and `sources` readiness.

--- a/distribution/codex/.codex/agents/conductor.md
+++ b/distribution/codex/.codex/agents/conductor.md
@@ -38,9 +38,10 @@ background work — and use only the governed engine operations:
 3. **Submit**: run `proposal --submit <workflow-id>` — the engine reads
    the kit files from disk, so never paste evidence or the recording into
    the conversation. Report each returned packet hash to the human.
-4. **Stop at the gate**: the human decides via `review`; publication goes
-   through `publish` with the current-context JSON the kit README
-   describes. Never infer a decision from conversation.
+4. **Stop at the gate**: run `publish` bare to show the human what awaits
+   them; their decision is `publish <proposal-id> --approve|--reject` —
+   approval lands the concept atomically and query answers immediately.
+   Never infer a decision from conversation.
 
 ## When to use this agent
 

--- a/distribution/codex/.codex/agents/conductor.toml
+++ b/distribution/codex/.codex/agents/conductor.toml
@@ -36,9 +36,10 @@ background work — and use only the governed engine operations:
 3. **Submit**: run `proposal --submit <workflow-id>` — the engine reads
    the kit files from disk, so never paste evidence or the recording into
    the conversation. Report each returned packet hash to the human.
-4. **Stop at the gate**: the human decides via `review`; publication goes
-   through `publish` with the current-context JSON the kit README
-   describes. Never infer a decision from conversation.
+4. **Stop at the gate**: run `publish` bare to show the human what awaits
+   them; their decision is `publish <proposal-id> --approve|--reject` —
+   approval lands the concept atomically and query answers immediately.
+   Never infer a decision from conversation.
 
 ## When to use this agent
 

--- a/distribution/kiro-ide/.kiro/agents/conductor.md
+++ b/distribution/kiro-ide/.kiro/agents/conductor.md
@@ -33,9 +33,10 @@ background work — and use only the governed engine operations:
 3. **Submit**: run `proposal --submit <workflow-id>` — the engine reads
    the kit files from disk, so never paste evidence or the recording into
    the conversation. Report each returned packet hash to the human.
-4. **Stop at the gate**: the human decides via `review`; publication goes
-   through `publish` with the current-context JSON the kit README
-   describes. Never infer a decision from conversation.
+4. **Stop at the gate**: run `publish` bare to show the human what awaits
+   them; their decision is `publish <proposal-id> --approve|--reject` —
+   approval lands the concept atomically and query answers immediately.
+   Never infer a decision from conversation.
 
 ## When to use this agent
 

--- a/distribution/kiro-ide/.kiro/skills/kdlc-publish/SKILL.md
+++ b/distribution/kiro-ide/.kiro/skills/kdlc-publish/SKILL.md
@@ -4,11 +4,11 @@ description: Run the governed K-DLC publish operation
 user-invocable: true
 ---
 
-**When to use:** Approved knowledge should become visible at its access level.
+**When to use:** You want to see what's waiting on your decision, or decide it — this is the human gate.
 
-**What you give it:** The approved item to publish.
+**What you give it:** Nothing to list pending review packets; or <proposal-id> --approve "reason" (or --reject / --request-changes) to decide and land it in one step.
 
-**What you get back:** Published, versioned knowledge — refused if approvals are missing.
+**What you get back:** On approval: the concept file, index, and retrieval catalog updated atomically — kdlc query answers with citations immediately. Refusals and rejections change nothing.
 
 **Usually next:** kdlc query to see it live; kdlc status for the audit trail.
 

--- a/distribution/kiro-ide/.kiro/skills/kdlc-start/SKILL.md
+++ b/distribution/kiro-ide/.kiro/skills/kdlc-start/SKILL.md
@@ -22,9 +22,10 @@ Follow this routine (read-only assessment first — never mutate while assessing
      user for --access and --license — governance decisions), then follow the
      kit README under `.kdlc/drafting/<workflow>/` to draft and submit.
      Work in the foreground and report the returned packet hashes.
-   - Proposals pending review → present the review packet and its hash; the
-     user's decision goes through the governed `review` operation.
-   - Approved but unpublished → offer `publish`.
+   - Proposals pending review → run `publish` bare to list them, present
+     each packet and hash, and record the user's decision with
+     `publish <proposal-id> --approve|--reject|--request-changes` — on
+     approval the concept lands atomically and query answers immediately.
    - Published knowledge present → offer `query`, `refresh`, or `gaps`.
    - Remote connectors configured but not ready → point at the
      connector-setup agent and `sources` readiness.

--- a/distribution/kiro/.kiro/agents/conductor.md
+++ b/distribution/kiro/.kiro/agents/conductor.md
@@ -33,9 +33,10 @@ background work — and use only the governed engine operations:
 3. **Submit**: run `proposal --submit <workflow-id>` — the engine reads
    the kit files from disk, so never paste evidence or the recording into
    the conversation. Report each returned packet hash to the human.
-4. **Stop at the gate**: the human decides via `review`; publication goes
-   through `publish` with the current-context JSON the kit README
-   describes. Never infer a decision from conversation.
+4. **Stop at the gate**: run `publish` bare to show the human what awaits
+   them; their decision is `publish <proposal-id> --approve|--reject` —
+   approval lands the concept atomically and query answers immediately.
+   Never infer a decision from conversation.
 
 ## When to use this agent
 

--- a/distribution/kiro/.kiro/skills/kdlc-publish/SKILL.md
+++ b/distribution/kiro/.kiro/skills/kdlc-publish/SKILL.md
@@ -4,11 +4,11 @@ description: Run the governed K-DLC publish operation
 user-invocable: true
 ---
 
-**When to use:** Approved knowledge should become visible at its access level.
+**When to use:** You want to see what's waiting on your decision, or decide it — this is the human gate.
 
-**What you give it:** The approved item to publish.
+**What you give it:** Nothing to list pending review packets; or <proposal-id> --approve "reason" (or --reject / --request-changes) to decide and land it in one step.
 
-**What you get back:** Published, versioned knowledge — refused if approvals are missing.
+**What you get back:** On approval: the concept file, index, and retrieval catalog updated atomically — kdlc query answers with citations immediately. Refusals and rejections change nothing.
 
 **Usually next:** kdlc query to see it live; kdlc status for the audit trail.
 

--- a/distribution/kiro/.kiro/skills/kdlc-start/SKILL.md
+++ b/distribution/kiro/.kiro/skills/kdlc-start/SKILL.md
@@ -22,9 +22,10 @@ Follow this routine (read-only assessment first — never mutate while assessing
      user for --access and --license — governance decisions), then follow the
      kit README under `.kdlc/drafting/<workflow>/` to draft and submit.
      Work in the foreground and report the returned packet hashes.
-   - Proposals pending review → present the review packet and its hash; the
-     user's decision goes through the governed `review` operation.
-   - Approved but unpublished → offer `publish`.
+   - Proposals pending review → run `publish` bare to list them, present
+     each packet and hash, and record the user's decision with
+     `publish <proposal-id> --approve|--reject|--request-changes` — on
+     approval the concept lands atomically and query answers immediately.
    - Published knowledge present → offer `query`, `refresh`, or `gaps`.
    - Remote connectors configured but not ready → point at the
      connector-setup agent and `sources` readiness.

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -14,5 +14,5 @@
   "tools": ["project_init", "project_get", "project_list_mounts", "kb_search", "kb_fetch", "kb_trace", "kb_conflicts", "kb_gaps", "source_excerpt", "job_status", "ingest_start", "proposal_create", "review_submit", "publish_request", "job_cancel"],
   "transports": ["stdio", "streamable-http"],
   "pending_requirements": [],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:a541b3ee94251c635333214fa6af5fc7417a6095b6e15b1e76e674f550ba9b48"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:67070a5e882c374ea696261fdfd847cc28479028a63e053cd0d2ac3bd6260a49"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -1062,6 +1062,27 @@
           "tests/governance/drafting-scaffold.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-033",
+      "title": "Publish last mile: atomic materialization, auto current-context, approval gate",
+      "issue": 125,
+      "specification_sections": [
+        "5.1",
+        "14",
+        "25"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "packages/cli/index.mjs",
+          "packages/adapters/generate.mjs",
+          "packages/agents/definitions/index.mjs"
+        ],
+        "tests": [
+          "tests/governance/drafting-scaffold.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/packages/adapters/generate.mjs
+++ b/packages/adapters/generate.mjs
@@ -58,9 +58,9 @@ const COMMAND_GUIDANCE = {
     next: "kdlc publish for approved content; kdlc proposal to rework rejections.",
   },
   publish: {
-    when: "Approved knowledge should become visible at its access level.",
-    give: "The approved item to publish.",
-    get: "Published, versioned knowledge — refused if approvals are missing.",
+    when: "You want to see what's waiting on your decision, or decide it — this is the human gate.",
+    give: "Nothing to list pending review packets; or <proposal-id> --approve \"reason\" (or --reject / --request-changes) to decide and land it in one step.",
+    get: "On approval: the concept file, index, and retrieval catalog updated atomically — kdlc query answers with citations immediately. Refusals and rejections change nothing.",
     next: "kdlc query to see it live; kdlc status for the audit trail.",
   },
   status: {
@@ -149,9 +149,10 @@ Follow this routine (read-only assessment first — never mutate while assessing
      user for --access and --license — governance decisions), then follow the
      kit README under \`.kdlc/drafting/<workflow>/\` to draft and submit.
      Work in the foreground and report the returned packet hashes.
-   - Proposals pending review → present the review packet and its hash; the
-     user's decision goes through the governed \`review\` operation.
-   - Approved but unpublished → offer \`publish\`.
+   - Proposals pending review → run \`publish\` bare to list them, present
+     each packet and hash, and record the user's decision with
+     \`publish <proposal-id> --approve|--reject|--request-changes\` — on
+     approval the concept lands atomically and query answers immediately.
    - Published knowledge present → offer \`query\`, \`refresh\`, or \`gaps\`.
    - Remote connectors configured but not ready → point at the
      connector-setup agent and \`sources\` readiness.

--- a/packages/agents/definitions/index.mjs
+++ b/packages/agents/definitions/index.mjs
@@ -66,9 +66,10 @@ background work — and use only the governed engine operations:
 3. **Submit**: run \`proposal --submit <workflow-id>\` — the engine reads
    the kit files from disk, so never paste evidence or the recording into
    the conversation. Report each returned packet hash to the human.
-4. **Stop at the gate**: the human decides via \`review\`; publication goes
-   through \`publish\` with the current-context JSON the kit README
-   describes. Never infer a decision from conversation.`,
+4. **Stop at the gate**: run \`publish\` bare to show the human what awaits
+   them; their decision is \`publish <proposal-id> --approve|--reject\` —
+   approval lands the concept atomically and query answers immediately.
+   Never infer a decision from conversation.`,
   },
   {
     role: "curator",

--- a/packages/cli/index.mjs
+++ b/packages/cli/index.mjs
@@ -23,7 +23,8 @@ import {
   parseYamlArtifact,
 } from "../contracts/index.mjs";
 import { FederationResolver } from "../federation/index.mjs";
-import { createCoreSensors, scanLintContext, SensorRunner } from "../lifecycle/src/index.mjs";
+import { AuditWriter, createCoreSensors, scanLintContext, SensorRunner, TransactionManager, sha256Token } from "../lifecycle/src/index.mjs";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { guardRetriever, RevocationGuard } from "../erasure/index.mjs";
 import { createExtensionValidator, previewMigration } from "../extensions/index.mjs";
 import { PrincipalAuthority, ReviewContextAuthority, RuntimeTrustAuthority } from "../agents/index.mjs";
@@ -421,7 +422,7 @@ export class KdlcEngine {
           ...localOwnerIdentity(),
           review_roles: ["trust-reviewer"],
           scopes: ["read", "mutate", "review", "publish"],
-          clearance: "public",
+          clearance: "internal",
           compartments: [],
         },
       ],
@@ -839,8 +840,19 @@ export function parseCli(argv) {
     [input.proposal_id, input.decision, input.receipt_id] = positionals;
   }
   if (operation === "publish") {
-    [input.proposal_id, input.receipt_id] = positionals;
-    if (positionals[2]) input.current = JSON.parse(positionals[2]);
+    const flags = positionals.filter((value) => value.startsWith("--"));
+    const plain = positionals.filter((value, index) => !value.startsWith("--") && !(positionals[index - 1] === "--approve" || positionals[index - 1] === "--reject" || positionals[index - 1] === "--request-changes"));
+    const reasonFor = (flag) => {
+      const at = positionals.indexOf(flag);
+      return at !== -1 && positionals[at + 1] && !positionals[at + 1].startsWith("--") ? positionals[at + 1] : undefined;
+    };
+    if (flags.includes("--approve")) { input.decide = "approved"; input.reason = reasonFor("--approve"); }
+    else if (flags.includes("--reject")) { input.decide = "rejected"; input.reason = reasonFor("--reject"); }
+    else if (flags.includes("--request-changes")) { input.decide = "changes_requested"; input.reason = reasonFor("--request-changes"); }
+    [input.proposal_id, input.receipt_id] = plain;
+    if (input.proposal_id === undefined) delete input.proposal_id;
+    if (input.receipt_id === undefined) delete input.receipt_id;
+    if (plain[2]) input.current = JSON.parse(plain[2]);
   }
   if (operation === "proposal" && (positionals.includes("--scaffold") || positionals.includes("--submit"))) {
     const flag = (name) => {
@@ -1190,6 +1202,108 @@ export function createLocalProjectEngine(options = {}) {
         reviewContextSession: await contextSession(workflowId),
         ...(review ? { session: principalAuthority.establishReviewSession(principal.id, principal.review_roles[0]) } : {}),
       });
+      // FEAT-033 (#125): humans never assemble the publish current-context —
+      // every field already exists in the workflow's own durable records.
+      const deriveCurrent = async (workflowId, proposal) => {
+        const normalized = await store.get(`workflow/runs/${workflowId}/state/normalized-evidence.json`);
+        const record = policy.review_contexts.find((entry) => entry.workflow_id === workflowId)
+          ?? (await indexStore.exists(contextPath(workflowId)) ? await indexStore.readJson(contextPath(workflowId)) : null);
+        if (!record) throw missing("Trusted review context is unavailable");
+        return {
+          concept: structuredClone(proposal.concept.after),
+          target_revision: proposal.target.revision,
+          source_hashes: [normalized.source_hash],
+          resolved_dependencies: structuredClone(record.context.resolved.dependencies),
+          profile: structuredClone(record.context.resolved.profile),
+          policies: structuredClone(record.context.resolved.policies),
+        };
+      };
+      // FEAT-033: the last mile — after the verification chain authorizes
+      // publication, land the OKF concept and regenerate index + catalog in
+      // one journaled, crash-recoverable transaction (never half-published).
+      const materializePublication = async ({ workflowId, proposal }) => {
+        const project = JSON.parse(readFileSync(resolve(root, ".kdlc/project.json"), "utf8"));
+        const mount = project.mounts?.[0]?.alias ?? "primary";
+        const base = `knowledge/${mount}`;
+        const subjectPath = String(proposal.target.subject).replace(/^kb:\/\/[^/]+\//, "").replace(/[^A-Za-z0-9/_-]+/g, "-").toLowerCase();
+        if (!subjectPath || subjectPath.includes("..")) throw inputError(`proposal subject ${proposal.target.subject} does not yield a safe concept path`);
+        const conceptRelative = `concepts/${subjectPath}.md`;
+        const conceptId = conceptRelative.slice(0, -3); // retriever contract: id === path minus .md
+        const frontmatter = proposal.concept.after.frontmatter;
+        const conceptContent = `---\n${stringifyYaml(frontmatter)}---\n\n${String(proposal.concept.after.body).replace(/\n*$/, "\n")}`;
+        const kbConfigText = await indexStore.exists(`${base}/knowledge-base.yaml`) ? await indexStore.readText(`${base}/knowledge-base.yaml`) : null;
+        const kbAccess = kbConfigText ? parseYaml(kbConfigText)?.access?.classification ?? "internal" : "internal";
+        const catalogPath = `${base}/retrieval-catalog.json`;
+        const oldCatalog = await indexStore.exists(catalogPath) ? JSON.parse(await indexStore.readText(catalogPath)) : { version: "kdlc-retrieval-catalog-1", concepts: [] };
+        // Retrieval binds to frontmatter access and per-source access/rights.
+        // Concepts reviewed without them keep the pre-FEAT-033 contract —
+        // authorization recorded, nothing materialized — with the reason
+        // stated so the drafter can fix and re-review.
+        const missingMetadata = !frontmatter.access || typeof frontmatter.access.classification !== "string"
+          ? `the concept frontmatter lacks access.classification (e.g. "${kbAccess}")`
+          : (frontmatter.sources ?? []).filter((source) => typeof source.resource !== "string" || !source.access?.classification || !source.rights?.license)
+              .map((source) => `source "${source.id}" lacks resource/access/rights`).join("; ") || null;
+        if (missingMetadata) {
+          return { materialized: false, reason: `${missingMetadata} — retrieval binds to these reviewed fields, so the intent is recorded but the concept was not published to the knowledge base; add them in the drafting template and re-review` };
+        }
+        const entry = { id: conceptId, path: conceptRelative, byte_hash: sha256Token(conceptContent), access: structuredClone(frontmatter.access) };
+        const catalog = { ...oldCatalog, concepts: [...oldCatalog.concepts.filter((item) => item.id !== conceptId), entry].sort((a, b) => a.id.localeCompare(b.id)) };
+        const catalogContent = `${JSON.stringify(catalog)}\n`;
+        const indexPathRel = `${base}/index.md`;
+        const oldIndex = await indexStore.exists(indexPathRel) ? await indexStore.readText(indexPathRel) : "<!-- generated by kdlc; do not edit -->\n# Knowledge Index\n";
+        const line = `* [${String(frontmatter.title ?? conceptId).replace(/[\[\]\n]/g, " ")}](${conceptRelative})`;
+        const kept = oldIndex.split("\n").filter((existing) => existing.trim().length > 0 && !existing.includes(`](${conceptRelative})`));
+        const indexContent = `${[...kept, line].join("\n")}\n`;
+        const priorToken = async (path) => (await indexStore.exists(path)) ? sha256Token(await indexStore.readText(path)) : null;
+        if (await priorToken(`${base}/${conceptRelative}`) === sha256Token(conceptContent)) {
+          return { materialized: true, concept: `${base}/${conceptRelative}`, index: indexPathRel, catalog: catalogPath, already_published: true };
+        }
+        const transactions = new TransactionManager({
+          store: indexStore,
+          clock: { now: () => new Date().toISOString(), millis: () => Date.now() },
+          ids: { next: (prefix) => `${prefix}_${randomBytes(8).toString("hex")}` },
+          token: sha256Token,
+          audit: new AuditWriter({ store: indexStore, clock: { now: () => new Date().toISOString(), millis: () => Date.now() }, ids: { next: (prefix) => `${prefix}_${randomBytes(8).toString("hex")}` } }),
+        });
+        const journal = await transactions.prepare({
+          workflowId,
+          targets: [
+            { path: `${base}/${conceptRelative}`, expectedToken: await priorToken(`${base}/${conceptRelative}`), content: conceptContent },
+            { path: indexPathRel, expectedToken: await priorToken(indexPathRel), content: indexContent },
+            { path: catalogPath, expectedToken: await priorToken(catalogPath), content: catalogContent },
+          ],
+        });
+        try {
+          await transactions.commit(workflowId, journal.transaction_id);
+        } catch (error) {
+          // Content is journaled: finalization hiccups roll forward, never
+          // leave the KB half-published.
+          if (error?.code === "KDLC_TRANSACTION_FINALIZATION_PENDING") await transactions.recover(workflowId, journal.transaction_id, "rollforward");
+          else throw error;
+        }
+        return { materialized: true, concept: `${base}/${conceptRelative}`, index: indexPathRel, catalog: catalogPath, transaction_id: journal.transaction_id };
+      };
+      // FEAT-033: the human gate — list what awaits decision, in plain terms.
+      const pendingReviews = async () => {
+        const directory = resolve(root, ".kdlc/governed/proposal-index");
+        if (!existsSync(directory)) return { pending: [] };
+        const pending = [];
+        for (const name of (await readdir(directory)).filter((item) => item.endsWith(".json")).sort()) {
+          const record = JSON.parse(await readFile(resolve(directory, name), "utf8"));
+          const decided = await indexStore.exists(`.kdlc/governed/workflow/runs/${record.workflow_id}/reviews/${record.proposal_id}/decision.json`);
+          if (decided) continue;
+          const proposal = await store.get(`workflow/runs/${record.workflow_id}/proposals/${record.proposal_id}.json`).catch(() => null);
+          pending.push({
+            proposal_id: record.proposal_id,
+            workflow_id: record.workflow_id,
+            packet_hash: record.packet_hash,
+            title: proposal?.concept?.after?.frontmatter?.title ?? record.proposal_id,
+            subject: proposal?.target?.subject ?? null,
+            next: `kdlc publish ${record.proposal_id} --approve "<reason>" (or --reject / --request-changes)`,
+          });
+        }
+        return { pending, ...(pending.length === 0 ? { note: "nothing is waiting on you" } : {}) };
+      };
       governed = {
         proposal_create: async ({ proposal }) => {
           const workflowId = proposal?.workflow_id;
@@ -1222,13 +1336,27 @@ export function createLocalProjectEngine(options = {}) {
           const runtime = await harness(index.workflow_id, true);
           return runtime.decide({ workflowId: index.workflow_id, proposalId, decision, receiptId });
         },
-        publish_request: async ({ proposal_id: proposalId, receipt_id: receiptId, current }) => {
+        publish_request: async ({ proposal_id: proposalId, receipt_id: receiptId, current, decide, reason }) => {
+          if (proposalId === undefined) return pendingReviews();
           const index = await proposalIndex(proposalId);
+          if (decide) {
+            // --approve/--reject/--request-changes: record the human decision
+            // first; only approvals continue into publication.
+            const reviewRuntime = await harness(index.workflow_id, true);
+            receiptId = receiptId ?? `rr_${digest(`${proposalId}:${decide}:${Date.now()}`).slice(7, 19)}`;
+            await reviewRuntime.decide({ workflowId: index.workflow_id, proposalId, decision: decide, receiptId });
+            if (decide !== "approved") return { proposal_id: proposalId, decision: decide, receipt_id: receiptId, reason: reason ?? null, published: null };
+          }
+          if (!receiptId) throw inputError("publish requires a receipt id (or use --approve to decide and publish in one step)");
+          const proposal = await store.get(`workflow/runs/${index.workflow_id}/proposals/${proposalId}.json`);
+          const effectiveCurrent = current ?? await deriveCurrent(index.workflow_id, proposal);
           const runtime = await harness(index.workflow_id, true);
           const receipt = await store.get(`workflow/runs/${index.workflow_id}/receipts/${receiptId}.json`);
           const decision = await store.get(`workflow/runs/${index.workflow_id}/reviews/${proposalId}/decision.json`);
           trustAuthority.activateReview({ workflowId: index.workflow_id, receipt, decision });
-          return runtime.preparePublication({ workflowId: index.workflow_id, proposalId, receiptId, current });
+          const publication = await runtime.preparePublication({ workflowId: index.workflow_id, proposalId, receiptId, current: effectiveCurrent });
+          const published = await materializePublication({ workflowId: index.workflow_id, proposal });
+          return { ...publication, published, next: published.materialized ? "the concept is live — kdlc query answers with citations now" : published.reason };
         },
         reconcile_edits: async ({ proposal_id: proposalId, reviewed_proposal_id: reviewedProposalId, target, reviewed_concept: reviewedConcept, current_concept: currentConcept, receipt_id: receiptId }) => {
           const index = await proposalIndex(reviewedProposalId);
@@ -1361,7 +1489,11 @@ export function createLocalProjectEngine(options = {}) {
       "   trusted review context, but the claim schema requires the fields present).",
       "2. Add proposals: `kdlc.dev/concept-proposal/v1alpha1` entries with `id` matching pr_<lowercase+digits>,",
       "   `workflow_id: \"" + workflowId + "\"`, `task: \"ingest\"`, `state: \"review_pending\"`, a `target`",
-      "   (knowledge_base_id/revision/subject), the OKF `concept` ({before: null, after: {frontmatter, body}}),",
+      "   (knowledge_base_id/revision/subject), the OKF `concept` ({before: null, after: {frontmatter, body}}) —",
+      "   frontmatter MUST include `access: {classification: \"" + access + "\"}` (retrieval binds to it) and",
+      "   each `sources` entry MUST carry `id`, `resource` (e.g. \"file:sources/<name>\"), `source_hash`,",
+      "   `access` and `rights` matching this kit's declarations (answers are withheld unless the requester",
+      "   may see the concept AND every disclosed source),",
       "   `claim_ids` listing every claim the concept rests on, `claim_decisions`",
       "   ([{claim_id, disposition: \"accepted\", rationale}]), and `created_by` (e.g. \"kdlc-integrator/0.2.0\").",
       "3. Set model.model and model.prompt to what actually drafted the content.",

--- a/packages/cli/index.mjs
+++ b/packages/cli/index.mjs
@@ -1255,8 +1255,21 @@ export function createLocalProjectEngine(options = {}) {
         const kept = oldIndex.split("\n").filter((existing) => existing.trim().length > 0 && !existing.includes(`](${conceptRelative})`));
         const indexContent = `${[...kept, line].join("\n")}\n`;
         const priorToken = async (path) => (await indexStore.exists(path)) ? sha256Token(await indexStore.readText(path)) : null;
-        if (await priorToken(`${base}/${conceptRelative}`) === sha256Token(conceptContent)) {
+        const existingConceptToken = await priorToken(`${base}/${conceptRelative}`);
+        if (existingConceptToken === sha256Token(conceptContent)) {
           return { materialized: true, concept: `${base}/${conceptRelative}`, index: indexPathRel, catalog: catalogPath, already_published: true };
+        }
+        // A creation proposal (concept.before === null) was reviewed as NEW
+        // content. Lossy subject sanitization can collide distinct subjects
+        // onto one path — the CAS must refuse, never bless a silent overwrite
+        // of a different reviewed concept (review round HIGH).
+        if (proposal.concept.before === null && existingConceptToken !== null) {
+          throw new EngineError(
+            "KDLC_STATE_CONFLICT",
+            `a different concept already occupies ${conceptRelative} (subjects may collide after path sanitization) — this proposal was reviewed as a creation, so publishing it would silently destroy reviewed content; re-draft it as an update (concept.before set to the current content) or choose a distinct subject`,
+            EXIT.conflict,
+            { path: `${base}/${conceptRelative}` },
+          );
         }
         const transactions = new TransactionManager({
           store: indexStore,
@@ -1268,7 +1281,7 @@ export function createLocalProjectEngine(options = {}) {
         const journal = await transactions.prepare({
           workflowId,
           targets: [
-            { path: `${base}/${conceptRelative}`, expectedToken: await priorToken(`${base}/${conceptRelative}`), content: conceptContent },
+            { path: `${base}/${conceptRelative}`, expectedToken: proposal.concept.before === null ? null : existingConceptToken, content: conceptContent },
             { path: indexPathRel, expectedToken: await priorToken(indexPathRel), content: indexContent },
             { path: catalogPath, expectedToken: await priorToken(catalogPath), content: catalogContent },
           ],
@@ -1344,7 +1357,20 @@ export function createLocalProjectEngine(options = {}) {
             // first; only approvals continue into publication.
             const reviewRuntime = await harness(index.workflow_id, true);
             receiptId = receiptId ?? `rr_${digest(`${proposalId}:${decide}:${Date.now()}`).slice(7, 19)}`;
-            await reviewRuntime.decide({ workflowId: index.workflow_id, proposalId, decision: decide, receiptId });
+            try {
+              await reviewRuntime.decide({ workflowId: index.workflow_id, proposalId, decision: decide, receiptId });
+            } catch (error) {
+              if (error?.code === "KDLC_DECISION_CONFLICT") {
+                throw new EngineError("KDLC_STATE_CONFLICT", `${proposalId} already has a recorded decision (receipt ${error.details?.current ?? "on file"}) — your earlier decision stands; finish with: kdlc publish ${proposalId} ${error.details?.current ?? "<receipt-id>"}`, EXIT.conflict, structuredClone(error.details ?? {}));
+              }
+              throw error;
+            }
+            // The human's stated rationale is part of the governance record.
+            await indexStore.writeJsonAtomic(`.kdlc/governed/workflow/runs/${index.workflow_id}/reviews/${proposalId}/rationale.json`, {
+              api_version: "kdlc.dev/review-rationale/v1",
+              proposal_id: proposalId, receipt_id: receiptId, decision: decide,
+              reason: reason ?? null, decided_by: principal.actor, decided_at: new Date().toISOString(),
+            });
             if (decide !== "approved") return { proposal_id: proposalId, decision: decide, receipt_id: receiptId, reason: reason ?? null, published: null };
           }
           if (!receiptId) throw inputError("publish requires a receipt id (or use --approve to decide and publish in one step)");

--- a/tests/governance/drafting-scaffold.test.mjs
+++ b/tests/governance/drafting-scaffold.test.mjs
@@ -58,7 +58,7 @@ test("FEAT-030: scaffold → fill → submit → review → publish runs end to 
     api_version: "kdlc.dev/concept-proposal/v1alpha1", id: "pr_token", workflow_id: scaffold.workflow_id,
     task: "ingest", state: "review_pending",
     target: { knowledge_base_id: "local.scaffold-fixture", revision: "rev-1", subject: "kb://local.scaffold-fixture/policies/token-lifetime" },
-    concept: { before: null, after: { frontmatter: { type: "Policy", title: "API token lifetime", description: "Token lifetime policy.", status: "stable", generated: { by: "kdlc-integrator/0.2.0", at: "2026-08-16T20:30:00Z" }, sources: [{ id: "spec", source_hash: evidence.source_hash }], stale_after: "2030-01-01" }, body: "# API token lifetime\n\nProduction API tokens expire after 60 minutes.\n" } },
+    concept: { before: null, after: { frontmatter: { type: "Policy", title: "API token lifetime", description: "Token lifetime policy.", status: "stable", access: { classification: "internal" }, generated: { by: "kdlc-integrator/0.2.0", at: "2026-08-16T20:30:00Z" }, sources: [{ id: "spec", resource: "file:spec.md", source_hash: evidence.source_hash, access: { classification: "internal" }, rights }], stale_after: "2030-01-01" }, body: "# API token lifetime\n\nProduction API tokens expire after 60 minutes.\n" } },
     claim_ids: ["clm_token"],
     claim_decisions: [{ claim_id: "clm_token", disposition: "accepted", rationale: "explicit statement" }],
     created_by: "kdlc-integrator/0.2.0"
@@ -81,6 +81,67 @@ test("FEAT-030: scaffold → fill → submit → review → publish runs end to 
   const publication = await engine.execute("publish", { proposal_id: "pr_token", receipt_id: "rr_token", current });
   assert.equal(publication.intent.proposal_id, "pr_token");
   assert.equal(publication.intent.packet_hash, submitted.proposals[0].packet_hash);
+  // FEAT-033: the last mile — concept file, index, catalog land atomically…
+  assert.equal(publication.published.materialized, true);
+  const conceptText = await readFile(join(root, publication.published.concept), "utf8");
+  assert.match(conceptText, /^---\n/);
+  assert.match(conceptText, /Production API tokens expire after 60 minutes\./);
+  assert.match(await readFile(join(root, "knowledge/primary/index.md"), "utf8"), /API token lifetime/);
+  // …republish is idempotent…
+  const again = await engine.execute("publish", { proposal_id: "pr_token", receipt_id: "rr_token", current });
+  assert.equal(again.published.already_published, true);
+  // …and query answers with revision-pinned citations immediately.
+  const answer = await engine.execute("query", { question: "what is the token lifetime?" });
+  assert.equal(answer.status, "ok");
+  assert.equal(answer.results[0].title, "API token lifetime");
+  assert.match(answer.citations[0].concept, /^kb:\/\/scaffold\.fixture@sha256:[a-f0-9]{64}\//);
+});
+
+test("FEAT-033: bare publish lists the gate; --approve chains decision and atomic landing with auto current-context", async () => {
+  const root = await mkdtemp(join(tmpdir(), "kdlc-gate-"));
+  await new KdlcEngine({ root }).execute("init", { project_id: "gate.fixture" });
+  const engine = createLocalProjectEngine({ root });
+  const job = await completedIngest(engine, root, "spec.md", "# Spec\n\n## Retention\n\nBackups are kept for 35 days.\n");
+  const scaffold = await engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "LicenseRef-Internal" } });
+  const kit = join(root, ".kdlc/drafting", scaffold.workflow_id);
+  const evidence = JSON.parse(await readFile(join(kit, "normalized-evidence.json"), "utf8"));
+  const template = JSON.parse(await readFile(join(kit, "recording-template.json"), "utf8"));
+  const unit = evidence.units.find(({ text }) => /35 days/.test(text));
+  const rights = { license: "LicenseRef-Internal", redistribution: "prohibited", derivative_use: "allowed", commercial_use: "prohibited" };
+  template.model = { provider: "recorded", model: "test-model", prompt: "gate", recorded_at: template.model.recorded_at };
+  template.claims = [{ id: "clm_ret", text: unit.text, source_id: evidence.source_id, source_hash: evidence.source_hash, locator: unit.locator, extraction: "explicit", status: "accepted", access: { classification: "internal" }, rights }];
+  template.proposals = [{ api_version: "kdlc.dev/concept-proposal/v1alpha1", id: "pr_ret", workflow_id: scaffold.workflow_id, task: "ingest", state: "review_pending", target: { knowledge_base_id: "local.gate.fixture", revision: "rev-1", subject: "kb://local.gate.fixture/policies/retention" }, concept: { before: null, after: { frontmatter: { type: "Policy", title: "Backup retention", description: "Retention policy.", status: "stable", access: { classification: "internal" }, generated: { by: "kdlc-integrator/0.2.0", at: "2026-08-16T20:30:00Z" }, sources: [{ id: "spec", resource: "file:spec.md", source_hash: evidence.source_hash, access: { classification: "internal" }, rights }], stale_after: "2030-01-01" }, body: "# Backup retention\n\nBackups are kept for 35 days.\n" } }, claim_ids: ["clm_ret"], claim_decisions: [{ claim_id: "clm_ret", disposition: "accepted", rationale: "explicit" }], created_by: "kdlc-integrator/0.2.0" }];
+  await writeFile(join(kit, "recording-template.json"), JSON.stringify(template));
+  await engine.execute("proposal", { submit: { workflow_id: scaffold.workflow_id } });
+
+  const gate = await engine.execute("publish", {});
+  assert.equal(gate.pending.length, 1);
+  assert.equal(gate.pending[0].proposal_id, "pr_ret");
+  assert.match(gate.pending[0].next, /--approve/);
+
+  const landed = await engine.execute("publish", { proposal_id: "pr_ret", decide: "approved", reason: "explicit and anchored" });
+  assert.equal(landed.published.materialized, true, JSON.stringify(landed.published));
+  assert.equal((await engine.execute("publish", {})).pending.length, 0);
+  const answer = await engine.execute("query", { question: "how long are backups kept?" });
+  assert.equal(answer.status, "ok");
+  assert.match(answer.results[0].title, /Backup retention/);
+
+  // Rejection path never publishes.
+  const job2 = await completedIngest(engine, root, "note.md", "# N\n\n## Extra\n\nAnother fact here.\n");
+  const scaffold2 = await engine.execute("proposal", { scaffold: { job_id: job2.id, access: "internal", license: "LicenseRef-Internal" } });
+  const kit2 = join(root, ".kdlc/drafting", scaffold2.workflow_id);
+  const evidence2 = JSON.parse(await readFile(join(kit2, "normalized-evidence.json"), "utf8"));
+  const template2 = JSON.parse(await readFile(join(kit2, "recording-template.json"), "utf8"));
+  const unit2 = evidence2.units.find(({ text }) => /Another fact/.test(text));
+  template2.model = { provider: "recorded", model: "test-model", prompt: "gate", recorded_at: template2.model.recorded_at };
+  template2.claims = [{ id: "clm_x", text: unit2.text, source_id: evidence2.source_id, source_hash: evidence2.source_hash, locator: unit2.locator, extraction: "explicit", status: "accepted", access: { classification: "internal" }, rights }];
+  template2.proposals = [{ ...template.proposals[0], id: "pr_x", workflow_id: scaffold2.workflow_id, target: { knowledge_base_id: "local.gate.fixture", revision: "rev-1", subject: "kb://local.gate.fixture/notes/extra" }, claim_ids: ["clm_x"], claim_decisions: [{ claim_id: "clm_x", disposition: "accepted", rationale: "r" }] }];
+  template2.proposals[0].concept = { before: null, after: { ...template.proposals[0].concept.after, frontmatter: { ...template.proposals[0].concept.after.frontmatter, title: "Extra note", sources: [{ id: "note", resource: "file:note.md", source_hash: evidence2.source_hash, access: { classification: "internal" }, rights }] } } };
+  await writeFile(join(kit2, "recording-template.json"), JSON.stringify(template2));
+  await engine.execute("proposal", { submit: { workflow_id: scaffold2.workflow_id } });
+  const rejected = await engine.execute("publish", { proposal_id: "pr_x", decide: "rejected", reason: "not needed" });
+  assert.equal(rejected.published, null);
+  assert.ok(!(await readFile(join(root, "knowledge/primary/index.md"), "utf8")).includes("Extra note"));
 });
 
 test("FEAT-030: the CLI accepts the scaffold flags and refuses malformed access", async () => {

--- a/tests/governance/drafting-scaffold.test.mjs
+++ b/tests/governance/drafting-scaffold.test.mjs
@@ -215,3 +215,38 @@ test("FEAT-032: unit slicing drafts a section whose anchors still verify; text o
   const json = renderEnvelope(envelope, "json");
   assert.ok(json.includes("First fact."), "JSON envelope keeps full fidelity");
 });
+
+test("FEAT-033: sanitized-subject collisions refuse instead of silently destroying reviewed concepts (review HIGH)", async () => {
+  const root = await mkdtemp(join(tmpdir(), "kdlc-collide-"));
+  await new KdlcEngine({ root }).execute("init", { project_id: "collide.fixture" });
+  const engine = createLocalProjectEngine({ root });
+  const rights = { license: "LicenseRef-Internal", redistribution: "prohibited", derivative_use: "allowed", commercial_use: "prohibited" };
+  const publishOne = async (tag, subject, body) => {
+    const job = await completedIngest(engine, root, `${tag}.md`, `# ${tag}\n\n## Fact\n\nThe ${tag} fact is recorded here.\n`);
+    const scaffold = await engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "LicenseRef-Internal" } });
+    const kit = join(root, ".kdlc/drafting", scaffold.workflow_id);
+    const evidence = JSON.parse(await readFile(join(kit, "normalized-evidence.json"), "utf8"));
+    const template = JSON.parse(await readFile(join(kit, "recording-template.json"), "utf8"));
+    const unit = evidence.units.find(({ text }) => /fact is recorded/.test(text));
+    template.model = { provider: "recorded", model: "t", prompt: "p", recorded_at: template.model.recorded_at };
+    template.claims = [{ id: `clm_${tag}`, text: unit.text, source_id: evidence.source_id, source_hash: evidence.source_hash, locator: unit.locator, extraction: "explicit", status: "accepted", access: { classification: "internal" }, rights }];
+    template.proposals = [{ api_version: "kdlc.dev/concept-proposal/v1alpha1", id: `pr_${tag}`, workflow_id: scaffold.workflow_id, task: "ingest", state: "review_pending", target: { knowledge_base_id: "local.collide", revision: "rev-1", subject }, concept: { before: null, after: { frontmatter: { type: "Policy", title: `T ${tag}`, description: "d", status: "stable", access: { classification: "internal" }, generated: { by: "kdlc-integrator/0.2.0", at: "2026-08-16T20:30:00Z" }, sources: [{ id: tag, resource: `file:${tag}.md`, source_hash: evidence.source_hash, access: { classification: "internal" }, rights }], stale_after: "2030-01-01" }, body: `# ${tag}\n\n${body}\n` } }, claim_ids: [`clm_${tag}`], claim_decisions: [{ claim_id: `clm_${tag}`, disposition: "accepted", rationale: "r" }], created_by: "kdlc-integrator/0.2.0" }];
+    await writeFile(join(kit, "recording-template.json"), JSON.stringify(template));
+    await engine.execute("proposal", { submit: { workflow_id: scaffold.workflow_id } });
+    return engine.execute("publish", { proposal_id: `pr_${tag}`, decide: "approved", reason: "test" });
+  };
+  const first = await publishOne("alpha", "kb://local.collide/policies/my-topic", "First content.");
+  assert.equal(first.published.materialized, true);
+  const firstBytes = await readFile(join(root, first.published.concept), "utf8");
+  // Distinct subject, same sanitized path — must refuse, first concept intact.
+  await assert.rejects(publishOne("beta", "kb://local.collide/policies/My.Topic", "Attacker content."),
+    (error) => error.code === "KDLC_STATE_CONFLICT" && /reviewed as a creation/.test(error.message));
+  assert.equal(await readFile(join(root, first.published.concept), "utf8"), firstBytes, "first concept untouched");
+  // Rationale sidecar persisted for the approval.
+  const rationale = JSON.parse(await readFile(join(root, `.kdlc/governed/workflow/runs/${first.intent.workflow_id}/reviews/pr_alpha/rationale.json`), "utf8"));
+  assert.equal(rationale.reason, "test");
+  assert.match(rationale.decided_by, /^human:/);
+  // Duplicate --approve gets an actionable message naming the receipt.
+  await assert.rejects(engine.execute("publish", { proposal_id: "pr_alpha", decide: "approved" }),
+    (error) => error.code === "KDLC_STATE_CONFLICT" && /already has a recorded decision/.test(error.message) && /kdlc publish pr_alpha rr_/.test(error.message));
+});


### PR DESCRIPTION
Closes #125

## Traceability

- Requirement IDs: FEAT-033
- Specification sections: §5.1, §14, §25

## Summary

Publish previously stopped at the authorization intent — concepts never landed, indexes never updated, query stayed empty forever (verified live). Now the loop closes:

- **Atomic materialization** — after the unchanged verification chain, publish writes the OKF concept into `knowledge/<mount>/concepts/…`, and regenerates `index.md` + `retrieval-catalog.json`, all through the journaled `TransactionManager` (locked targets, crash roll-forward, never half-published). Republishing identical content is idempotent (`already_published`). Concepts reviewed without retrieval-required metadata (frontmatter `access`, per-source `resource`/`access`/`rights`) keep the old record-intent-only contract with the reason stated — which also keeps the pinned transport-equivalence fixtures green without choreography.
- **The human gate** — bare `kdlc publish` lists pending review packets in plain language; `kdlc publish <id> --approve "reason"` (or `--reject`/`--request-changes`) chains the decision and, on approval, the landing. The **current-context is auto-derived** from the workflow's own durable records — humans never assemble that JSON (explicit `current` still accepted for automation).
- **Retrieval actually answers now**: the end-to-end test runs ingest → scaffold → fill → submit → `--approve` → **`query` returns the concept with a revision-pinned citation and per-source rights**. Also fixed en route: catalog ids follow the retriever's `path-minus-.md` contract; the local owner's default clearance is `internal` so owners can read their own KB; audit clock supplies `millis` (finalization no longer stalls, with roll-forward recovery as backstop).
- Kit README, conductor playbook, and command guidance updated (frontmatter/source metadata requirements; the one-command gate).

## Verification

Commands and results:

```
$ npm test
tests 296 / pass 296 / fail 0   (extended e2e asserts files land, republish is idempotent, rejection changes nothing, and query cites)

$ kdlc publish pr_tok --approve "well anchored"   # live clean-room run
  published: {…concepts/policies/token-lifetime.md…}  → kdlc query: status ok, revision-pinned citation
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
