### PR TITLE
feat: bare kdlc front door and resumable batches (#129) [FEAT-035]

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,18 @@ Remote sources (Confluence, SharePoint, OneDrive, Google Drive) connect
 through the guided `connector-setup` agent — read-only scopes, secrets stay
 in environment variables ([guide](distribution/claude-code/guides/connecting-remote-sources.md)).
 
+## The five verbs
+
+Day to day you only need these — everything else is automation or inspection:
+
+```bash
+kdlc                    # start or resume: where you are + the next step
+kdlc ingest <files>     # feed it (folders, PDFs, Office, email, HTML, …)
+kdlc query "…"          # ask it — answers carry citations
+kdlc publish            # your gate: list what awaits you; <id> --approve "reason" lands it
+kdlc revisit            # ratify auto-published drafts into default answers
+```
+
 ## Automation & CI — the engine directly
 
 The same `kdlc` CLI the harnesses invoke is a stable surface for scripts and

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -14,5 +14,5 @@
   "tools": ["project_init", "project_get", "project_list_mounts", "kb_search", "kb_fetch", "kb_trace", "kb_conflicts", "kb_gaps", "source_excerpt", "job_status", "ingest_start", "proposal_create", "review_submit", "publish_request", "job_cancel"],
   "transports": ["stdio", "streamable-http"],
   "pending_requirements": [],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:cf63d162d30033a2b0ff5a38c34e4d9f0fd2dfd8f2d6c87f1b7a0b83bad239d5"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:51c127f9699631ded593239c00e57457181703101a49ac4a21a6372b15aa1653"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -1104,6 +1104,26 @@
           "tests/governance/drafting-scaffold.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-035",
+      "title": "Bare kdlc start/resume, scaffold skip-existing, tiered command palette",
+      "issue": 129,
+      "specification_sections": [
+        "25",
+        "34"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "packages/cli/bin.mjs",
+          "packages/cli/index.mjs",
+          "README.md"
+        ],
+        "tests": [
+          "tests/governance/drafting-scaffold.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/packages/cli/bin.mjs
+++ b/packages/cli/bin.mjs
@@ -6,15 +6,53 @@ import {
   renderEnvelope,
   EXIT,
 } from "./index.mjs";
+// FEAT-035 (#129): bare `kdlc` (or `kdlc resume`) is the front door — assess
+// durable state and say where you are and what's next, instead of a usage
+// error. Read-only; the JSON operation surface is untouched.
+async function assess() {
+  const { existsSync, readdirSync } = await import("node:fs");
+  const { resolve } = await import("node:path");
+  const root = process.cwd();
+  const lines = [];
+  if (!existsSync(resolve(root, ".kdlc/project.json"))) {
+    process.stdout.write("No K-DLC project here yet.\n  Next: kdlc init — then kdlc ingest <files> to bring in sources.\n  (For the guided experience, add K-DLC to your AI tool: kdlc setup <claude-code|codex|kiro|kiro-ide|mcp> <dir>.)\n");
+    return;
+  }
+  const engine = createLocalProjectEngine({ root });
+  const jobs = await engine.execute("jobs", {}).catch(() => ({ jobs: [] }));
+  const running = jobs.jobs.filter(({ state }) => ["queued", "running"].includes(state));
+  const failed = jobs.jobs.filter(({ state }) => state === "failed");
+  const draftingRoot = resolve(root, ".kdlc/drafting");
+  const kits = existsSync(draftingRoot) ? readdirSync(draftingRoot) : [];
+  const gate = await engine.execute("publish", {}).catch(() => ({ pending: [] }));
+  const queue = await engine.execute("revisit", {}).catch(() => ({ awaiting_ratification: [] }));
+  const sources = await engine.execute("sources", {}).catch(() => ({ sources: [] }));
+  lines.push(`Project ready. Evidence jobs: ${jobs.jobs.length} (${running.length} in flight, ${failed.length} failed). Drafting kits: ${kits.length}. Awaiting your decision: ${gate.pending?.length ?? 0}. Awaiting ratification: ${queue.awaiting_ratification?.length ?? 0}.`);
+  if (running.length) lines.push(`  Next: kdlc jobs — ${running.length} ingest job${running.length === 1 ? " is" : "s are"} still working.`);
+  else if (gate.pending?.length) lines.push(`  Next: kdlc publish — ${gate.pending.length} review packet${gate.pending.length === 1 ? "" : "s"} await${gate.pending.length === 1 ? "s" : ""} your decision (${gate.pending[0].proposal_id}: "${gate.pending[0].title}").`);
+  else if (queue.awaiting_ratification?.length) lines.push(`  Next: kdlc revisit — ${queue.awaiting_ratification.length} auto-published draft${queue.awaiting_ratification.length === 1 ? "" : "s"} await your ratification.`);
+  else if (kits.length) lines.push(`  Next: a drafting kit is open (${kits[0]}) — fill its recording template per the kit README, then kdlc proposal --submit ${kits[0]}.`);
+  else if (jobs.jobs.length && jobs.jobs.some(({ state }) => state === "completed")) lines.push("  Next: evidence is waiting — kdlc proposal --scaffold <job-id> to start drafting (kdlc jobs lists job ids).");
+  else lines.push("  Next: kdlc ingest <files> to bring in sources, or kdlc query \"…\" to ask published knowledge.");
+  const notReady = (sources.connectors?.connectors ?? []).filter(({ ready }) => !ready);
+  if (notReady.length) lines.push(`  Note: ${notReady.length} remote connector${notReady.length === 1 ? " is" : "s are"} not ready — kdlc sources shows what to set.`);
+  process.stdout.write(lines.join("\n") + "\n");
+}
 let parsed;
 try {
-  parsed = parseCli(process.argv.slice(2));
+  const argv = process.argv.slice(2);
+  if (argv.length === 0 || (argv.length === 1 && argv[0] === "resume")) {
+    await assess();
+    process.exitCode = EXIT.success;
+  } else {
+  parsed = parseCli(argv);
   const envelope = await createLocalProjectEngine().envelope(
     parsed.operation,
     parsed.input,
   );
   process.stdout.write(renderEnvelope(envelope, parsed.output));
   process.exitCode = envelope.ok ? EXIT.success : envelope.error.class;
+  }
 } catch (error) {
   const engine = new KdlcEngine();
   const envelope = await engine.envelope("cli", { error: error.message });

--- a/packages/cli/bin.mjs
+++ b/packages/cli/bin.mjs
@@ -6,43 +6,109 @@ import {
   renderEnvelope,
   EXIT,
 } from "./index.mjs";
-// FEAT-035 (#129): bare `kdlc` (or `kdlc resume`) is the front door — assess
-// durable state and say where you are and what's next, instead of a usage
-// error. Read-only; the JSON operation surface is untouched.
-async function assess() {
-  const { existsSync, readdirSync } = await import("node:fs");
+// FEAT-035 (#129): bare `kdlc` (or `kdlc resume`) is the front door — a
+// PURE-FILESYSTEM assessment of durable state (no engine, no job resumption,
+// no writes) that says where you are and what's next.
+async function assess(output) {
+  const { existsSync, readdirSync, readFileSync } = await import("node:fs");
   const { resolve } = await import("node:path");
   const root = process.cwd();
-  const lines = [];
+  const readJson = (path) => { try { return JSON.parse(readFileSync(path, "utf8")); } catch { return null; } };
+  const emit = (summary) => {
+    if (output === "json") { process.stdout.write(JSON.stringify(summary) + "\n"); return; }
+    process.stdout.write([summary.state, ...(summary.next ? [`  Next: ${summary.next}`] : []), ...(summary.notes ?? []).map((note) => `  Note: ${note}`)].join("\n") + "\n");
+  };
   if (!existsSync(resolve(root, ".kdlc/project.json"))) {
-    process.stdout.write("No K-DLC project here yet.\n  Next: kdlc init — then kdlc ingest <files> to bring in sources.\n  (For the guided experience, add K-DLC to your AI tool: kdlc setup <claude-code|codex|kiro|kiro-ide|mcp> <dir>.)\n");
+    emit({ state: "No K-DLC project here yet.", next: "kdlc init — then kdlc ingest <files> to bring in sources. (For the guided experience: kdlc setup <claude-code|codex|kiro|kiro-ide|mcp> <dir>.)" });
     return;
   }
-  const engine = createLocalProjectEngine({ root });
-  const jobs = await engine.execute("jobs", {}).catch(() => ({ jobs: [] }));
-  const running = jobs.jobs.filter(({ state }) => ["queued", "running"].includes(state));
-  const failed = jobs.jobs.filter(({ state }) => state === "failed");
+  if (readJson(resolve(root, ".kdlc/project.json")) === null) {
+    emit({ state: "The project record exists but cannot be read.", next: "kdlc doctor — diagnose and repair safely." });
+    return;
+  }
+  const jobsDirectory = resolve(root, ".kdlc/jobs");
+  const jobs = existsSync(jobsDirectory)
+    ? readdirSync(jobsDirectory).filter((name) => /^job_[a-f0-9]{16}\.json$/.test(name)).map((name) => readJson(resolve(jobsDirectory, name))).filter(Boolean)
+    : [];
+  const running = jobs.filter(({ state }) => ["queued", "running"].includes(state));
+  const failed = jobs.filter(({ state }) => state === "failed");
+  const governed = resolve(root, ".kdlc/governed");
+  // A drafting kit is OPEN only while its workflow has no submitted proposals.
   const draftingRoot = resolve(root, ".kdlc/drafting");
-  const kits = existsSync(draftingRoot) ? readdirSync(draftingRoot) : [];
-  const gate = await engine.execute("publish", {}).catch(() => ({ pending: [] }));
-  const queue = await engine.execute("revisit", {}).catch(() => ({ awaiting_ratification: [] }));
-  const sources = await engine.execute("sources", {}).catch(() => ({ sources: [] }));
-  lines.push(`Project ready. Evidence jobs: ${jobs.jobs.length} (${running.length} in flight, ${failed.length} failed). Drafting kits: ${kits.length}. Awaiting your decision: ${gate.pending?.length ?? 0}. Awaiting ratification: ${queue.awaiting_ratification?.length ?? 0}.`);
-  if (running.length) lines.push(`  Next: kdlc jobs — ${running.length} ingest job${running.length === 1 ? " is" : "s are"} still working.`);
-  else if (gate.pending?.length) lines.push(`  Next: kdlc publish — ${gate.pending.length} review packet${gate.pending.length === 1 ? "" : "s"} await${gate.pending.length === 1 ? "s" : ""} your decision (${gate.pending[0].proposal_id}: "${gate.pending[0].title}").`);
-  else if (queue.awaiting_ratification?.length) lines.push(`  Next: kdlc revisit — ${queue.awaiting_ratification.length} auto-published draft${queue.awaiting_ratification.length === 1 ? "" : "s"} await your ratification.`);
-  else if (kits.length) lines.push(`  Next: a drafting kit is open (${kits[0]}) — fill its recording template per the kit README, then kdlc proposal --submit ${kits[0]}.`);
-  else if (jobs.jobs.length && jobs.jobs.some(({ state }) => state === "completed")) lines.push("  Next: evidence is waiting — kdlc proposal --scaffold <job-id> to start drafting (kdlc jobs lists job ids).");
-  else lines.push("  Next: kdlc ingest <files> to bring in sources, or kdlc query \"…\" to ask published knowledge.");
-  const notReady = (sources.connectors?.connectors ?? []).filter(({ ready }) => !ready);
-  if (notReady.length) lines.push(`  Note: ${notReady.length} remote connector${notReady.length === 1 ? " is" : "s are"} not ready — kdlc sources shows what to set.`);
-  process.stdout.write(lines.join("\n") + "\n");
+  const openKits = (existsSync(draftingRoot) ? readdirSync(draftingRoot) : []).filter((workflowId) => {
+    const proposalsDirectory = resolve(governed, "workflow/runs", workflowId, "proposals");
+    return !existsSync(proposalsDirectory) || readdirSync(proposalsDirectory).length === 0;
+  });
+  const indexDirectory = resolve(governed, "proposal-index");
+  const pending = [];
+  if (existsSync(indexDirectory)) {
+    for (const name of readdirSync(indexDirectory).filter((item) => /^pr[a-z0-9_]*\.json$/.test(item))) {
+      const record = readJson(resolve(indexDirectory, name));
+      if (!record) continue;
+      if (existsSync(resolve(governed, "workflow/runs", record.workflow_id, "reviews", record.proposal_id, "decision.json"))) continue;
+      const proposal = readJson(resolve(governed, "workflow/runs", record.workflow_id, "proposals", `${record.proposal_id}.json`));
+      pending.push({ proposal_id: record.proposal_id, title: proposal?.concept?.after?.frontmatter?.title ?? record.proposal_id });
+    }
+  }
+  const awaiting = [];
+  const runsDirectory = resolve(governed, "workflow/runs");
+  if (existsSync(runsDirectory)) {
+    for (const workflowId of readdirSync(runsDirectory)) {
+      const reviewsDirectory = resolve(runsDirectory, workflowId, "reviews");
+      if (!existsSync(reviewsDirectory)) continue;
+      for (const proposalId of readdirSync(reviewsDirectory)) {
+        const rationale = readJson(resolve(reviewsDirectory, proposalId, "rationale.json"));
+        if (rationale?.auto && !rationale.ratified) awaiting.push(proposalId);
+      }
+    }
+  }
+  const notes = [];
+  const connectorsPath = resolve(root, ".kdlc/connectors.json");
+  if (existsSync(connectorsPath)) {
+    const parsed = readJson(connectorsPath);
+    if (parsed === null) notes.push("the remote-connector config is unreadable — kdlc sources shows the findings.");
+    else {
+      try {
+        const { connectorReadiness } = await import("../sources/config.mjs");
+        const readiness = connectorReadiness(parsed);
+        if (!readiness.valid) notes.push("the remote-connector config has problems — kdlc sources shows the findings.");
+        else {
+          const notReady = readiness.connectors.filter(({ ready }) => !ready);
+          if (notReady.length) notes.push(`${notReady.length} remote connector${notReady.length === 1 ? " is" : "s are"} not ready — kdlc sources shows what to set.`);
+        }
+      } catch { notes.push("the remote-connector config could not be checked — kdlc sources shows the findings."); }
+    }
+  }
+  const plural = (count, singular, pluralForm) => (count === 1 ? singular : pluralForm);
+  let published = 0;
+  const knowledgeRoot = resolve(root, "knowledge");
+  if (existsSync(knowledgeRoot)) {
+    for (const mount of readdirSync(knowledgeRoot)) {
+      const catalog = readJson(resolve(knowledgeRoot, mount, "retrieval-catalog.json"));
+      published += catalog?.concepts?.length ?? 0;
+    }
+  }
+  const state = `Project ready. Evidence jobs: ${jobs.length} (${running.length} in flight, ${failed.length} failed). Published concepts: ${published}. Open drafting kits: ${openKits.length}. Awaiting your decision: ${pending.length}. Awaiting ratification: ${awaiting.length}.`;
+  let next;
+  if (running.length) next = `kdlc jobs — ${running.length} ingest ${plural(running.length, "job is", "jobs are")} still working.`;
+  else if (pending.length) next = `kdlc publish — ${pending.length} review ${plural(pending.length, "packet awaits", "packets await")} your decision (${pending[0].proposal_id}: "${pending[0].title}").`;
+  else if (awaiting.length) next = `kdlc revisit — ${awaiting.length} auto-published ${plural(awaiting.length, "draft awaits", "drafts await")} your ratification.`;
+  else if (openKits.length) next = `a drafting kit is open (${openKits[0]}) — fill its recording template per the kit README, then kdlc proposal --submit ${openKits[0]}.`;
+  else if (failed.length) next = `kdlc jobs — ${failed.length} ${plural(failed.length, "job", "jobs")} failed; inspect and re-run.`;
+  else if (published > 0) next = `kdlc query "…" — ${published} ${plural(published, "concept is", "concepts are")} published and citable. Ingest more, or kdlc proposal --scaffold <job-id> to draft further from existing evidence.`;
+  else if (jobs.some(({ state: jobState }) => jobState === "completed")) next = "evidence is waiting — kdlc proposal --scaffold <job-id> to start drafting (kdlc jobs lists job ids).";
+  else next = 'kdlc ingest <files> to bring in sources, or kdlc query "…" to ask published knowledge.';
+  emit({ state, next, ...(notes.length ? { notes } : {}) });
 }
 let parsed;
 try {
   const argv = process.argv.slice(2);
-  if (argv.length === 0 || (argv.length === 1 && argv[0] === "resume")) {
-    await assess();
+  let assessOutput = "text";
+  const bare = [...argv];
+  const outputAt = bare.indexOf("--output");
+  if (outputAt !== -1 && ["text", "json", "human"].includes(bare[outputAt + 1])) { assessOutput = bare[outputAt + 1] === "human" ? "text" : bare[outputAt + 1]; bare.splice(outputAt, 2); }
+  if (bare.length === 0 || (bare.length === 1 && bare[0] === "resume")) {
+    await assess(assessOutput);
     process.exitCode = EXIT.success;
   } else {
   parsed = parseCli(argv);

--- a/packages/cli/index.mjs
+++ b/packages/cli/index.mjs
@@ -1531,14 +1531,27 @@ export function createLocalProjectEngine(options = {}) {
       sliceBounds = [Number(match[1]), Number(match[2])];
       if (sliceBounds[0] < 1 || sliceBounds[1] < sliceBounds[0]) throw inputError("--units range must satisfy 1 <= start <= end");
     }
-    const scaffolded = [];
+    const scaffolded = []; const skipped = [];
     for (const { artifact, index } of selection) {
       const workflowId = requestedWorkflow ?? (selection.length > 1 || source !== undefined ? `wf_${jobId.slice(4)}s${index}` : `wf_${jobId.slice(4)}`);
       if (!/^wf_[a-z0-9]+$/.test(workflowId)) throw inputError("workflow_id must match wf_<lowercase letters and digits> (the concept-proposal schema enforces it)");
-      scaffolded.push(await scaffoldOneSource({ artifact, workflowId, access, license, sliceBounds, sourceName: job.request?.sources?.[index] ?? artifact.manifest.source_id }));
+      try {
+        scaffolded.push(await scaffoldOneSource({ artifact, workflowId, access, license, sliceBounds, sourceName: job.request?.sources?.[index] ?? artifact.manifest.source_id }));
+      } catch (error) {
+        // Resumable batches (FEAT-035, #129): on an --all-sources re-run,
+        // already-scaffolded documents skip and the rest continue.
+        if (allSources && error?.code === "KDLC_STATE_CONFLICT") {
+          skipped.push({ workflow_id: workflowId, source: job.request?.sources?.[index] ?? artifact.manifest.source_id, reason: "already scaffolded" });
+          continue;
+        }
+        throw error;
+      }
+    }
+    if (allSources && scaffolded.length === 0 && skipped.length > 0) {
+      return { job_id: jobId, scaffolds: [], skipped, next: "every document is already scaffolded — fill the kits and submit with kdlc proposal --submit <workflow-id>" };
     }
     return withDefaultsNote(
-      selection.length === 1 ? scaffolded[0] : { job_id: jobId, scaffolds: scaffolded, next: "fill each kit's recording template, then submit each with kdlc proposal --submit <workflow-id>" },
+      selection.length === 1 ? scaffolded[0] : { job_id: jobId, scaffolds: scaffolded, ...(skipped.length ? { skipped } : {}), next: "fill each kit's recording template, then submit each with kdlc proposal --submit <workflow-id>" },
       usedDefaults, access, license,
     );
   };

--- a/tests/governance/cli-hints.test.mjs
+++ b/tests/governance/cli-hints.test.mjs
@@ -91,3 +91,39 @@ test("FEAT-031: coded refusals keep the exit-class taxonomy and never break the 
   assert.equal(hostile.error.code, "KDLC_MODEL_RECORDING_INVALID");
   assert.deepEqual(hostile.error.details, {});
 });
+
+test("FEAT-035: the bare front door is a pure-filesystem assessment — correct next steps, zero mutation", async () => {
+  const { execFileSync } = await import("node:child_process");
+  const { mkdtemp, writeFile: writeFsFile, readdir } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { join, resolve } = await import("node:path");
+  const bin = resolve("packages/cli/bin.mjs");
+  const empty = await mkdtemp(join(tmpdir(), "kdlc-bare-"));
+  const emptyOut = execFileSync(process.execPath, [bin], { cwd: empty }).toString();
+  assert.match(emptyOut, /No K-DLC project here yet/);
+  assert.match(emptyOut, /kdlc init/);
+  assert.deepEqual(await readdir(empty), [], "assessment creates nothing");
+
+  // Corrupt project record → doctor, not a fake "ready".
+  const broken = await mkdtemp(join(tmpdir(), "kdlc-broken-"));
+  const { mkdir: mkdirFs } = await import("node:fs/promises");
+  await mkdirFs(join(broken, ".kdlc"), { recursive: true });
+  await writeFsFile(join(broken, ".kdlc/project.json"), "{not json");
+  assert.match(execFileSync(process.execPath, [bin], { cwd: broken }).toString(), /cannot be read[\s\S]*kdlc doctor/);
+
+  // A queued job on disk is REPORTED, never resumed (review HIGH).
+  const queued = await mkdtemp(join(tmpdir(), "kdlc-queued-"));
+  await new KdlcEngine({ root: queued }).execute("init", { project_id: "queued.fixture" });
+  await mkdirFs(join(queued, ".kdlc/jobs"), { recursive: true });
+  const jobRecord = { api_version: "kdlc.dev/job/v1", id: "job_00000000000000aa", operation: "ingest", state: "queued", principal: "human:someone", request: { sources: ["x.md"] }, attempts: [], progress: { completed: 0, total: 0 }, created_at: "2026-08-16T00:00:00Z", updated_at: "2026-08-16T00:00:00Z", revision: 0, checkpoints: [], dependencies: {}, error: null, result: null, idempotency_key: "k", input_hashes: {}, resource_budget: {}, cancellation_requested: false, workflow_id: null };
+  await writeFsFile(join(queued, ".kdlc/jobs/job_00000000000000aa.json"), JSON.stringify(jobRecord));
+  const queuedOut = execFileSync(process.execPath, [bin], { cwd: queued }).toString();
+  assert.match(queuedOut, /1 in flight/);
+  assert.match(queuedOut, /kdlc jobs/);
+  const after = JSON.parse(await (await import("node:fs/promises")).readFile(join(queued, ".kdlc/jobs/job_00000000000000aa.json"), "utf8"));
+  assert.equal(after.state, "queued", "bare kdlc must not resume jobs");
+
+  // resume alias + JSON output.
+  const json = JSON.parse(execFileSync(process.execPath, [bin, "resume", "--output", "json"], { cwd: queued }).toString());
+  assert.match(json.state, /1 in flight/);
+});

--- a/tests/governance/drafting-scaffold.test.mjs
+++ b/tests/governance/drafting-scaffold.test.mjs
@@ -340,3 +340,32 @@ test("FEAT-034: auto mode requires an explicit draft status — omission and cas
   // Nothing reached default answers through any refused attempt.
   assert.equal((await engine.execute("query", { question: "guarded fact" })).status, "not_found");
 });
+
+test("FEAT-035: --all-sources re-runs skip already-scaffolded documents and continue", async () => {
+  const root = await mkdtemp(join(tmpdir(), "kdlc-skip-"));
+  await new KdlcEngine({ root }).execute("init", { project_id: "skip.fixture" });
+  const engine = createLocalProjectEngine({ root });
+  await writeFile(join(root, "a.md"), "# A\n\nFact A.\n");
+  await writeFile(join(root, "b.md"), "# B\n\nFact B.\n");
+  const started = await engine.execute("ingest_start", { sources: ["a.md", "b.md"], idempotency_key: "skip-1" });
+  let job = started;
+  for (let attempt = 0; attempt < 100 && !["completed", "failed"].includes(job.state); attempt += 1) {
+    await new Promise((r) => setTimeout(r, 50));
+    job = await engine.execute("job_status", { id: started.id });
+  }
+  const first = await engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "LicenseRef-Internal", all_sources: true } });
+  assert.equal(first.scaffolds.length, 2);
+  // Full re-run: everything skips, nothing throws, batch reports it.
+  const rerun = await engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "LicenseRef-Internal", all_sources: true } });
+  assert.equal(rerun.scaffolds.length, 0);
+  assert.equal(rerun.skipped.length, 2);
+  assert.match(rerun.next, /already scaffolded/);
+  // Partial: delete one context, re-run scaffolds only that one.
+  const { rm } = await import("node:fs/promises");
+  await rm(join(root, ".kdlc/governed/review-contexts", `${first.scaffolds[1].workflow_id}.json`));
+  await rm(join(root, ".kdlc/drafting", first.scaffolds[1].workflow_id), { recursive: true });
+  const partial = await engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "LicenseRef-Internal", all_sources: true } });
+  assert.equal(partial.scaffolds.length, 1);
+  assert.equal(partial.scaffolds[0].workflow_id, first.scaffolds[1].workflow_id);
+  assert.equal(partial.skipped.length, 1);
+});


### PR DESCRIPTION
Closes #129

## Traceability

- Requirement IDs: FEAT-035
- Specification sections: §25, §34

## Summary

The finale of the simplification arc:

- **Bare `kdlc` (and `kdlc resume`)** — instead of a usage error, the front door reads durable state (project, jobs, drafting kits, the publish gate, the ratification queue, connector readiness) and prints where you are plus exactly one next step, per state: uninitialized → init; jobs in flight → jobs; packets pending → publish (naming the first); drafts awaiting → revisit; kit open → submit it; evidence idle → scaffold; all quiet → ingest/query. Bin-level and read-only — the JSON operation surface is untouched. Smoke-verified live for the empty-dir and evidence-waiting states.
- **Resumable batches** — an `--all-sources` re-run now skips already-scaffolded documents and continues (previously the first collision aborted the batch); full re-runs report "every document is already scaffolded"; partial re-runs scaffold only the missing ones (test covers full + partial).
- **Tiered README** — "The five verbs" (kdlc / ingest / query / publish / revisit) lead the command documentation; automation and inspection tiers sit beneath.

## Verification

Commands and results:

```
$ npm test
tests 301 / pass 301 / fail 0

$ kdlc            # in an empty dir → "No K-DLC project here yet. Next: kdlc init …"
$ kdlc resume     # after ingest → "…evidence is waiting — kdlc proposal --scaffold <job-id>…"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
