### PR TITLE
fix: --show tolerates minimal frontmatter (#135) [FEAT-037]

### DIFF
--- a/packages/cli/index.mjs
+++ b/packages/cli/index.mjs
@@ -1343,7 +1343,7 @@ export function createLocalProjectEngine(options = {}) {
           claims.push({
             id: claim.id,
             claim: claim.text,
-            extraction: claim.extraction,
+            extraction: claim.extraction ?? null,
             source_excerpt: byLocator.get(canonicalJson(claim.locator)) ?? "(excerpt unavailable)",
             locator: claim.locator,
           });
@@ -1353,8 +1353,9 @@ export function createLocalProjectEngine(options = {}) {
         return {
           proposal_id: proposalId,
           title: frontmatter.title,
-          type: frontmatter.type,
-          status: frontmatter.status,
+          type: frontmatter.type ?? null,
+          // Omitted status resolves as stable at retrieval, so show that.
+          status: frontmatter.status ?? "stable",
           access: frontmatter.access ?? null,
           subject: proposal.target.subject,
           body: proposal.concept.after.body,

--- a/packages/cli/index.mjs
+++ b/packages/cli/index.mjs
@@ -1344,15 +1344,15 @@ export function createLocalProjectEngine(options = {}) {
             id: claim.id,
             claim: claim.text,
             extraction: claim.extraction ?? null,
-            source_excerpt: byLocator.get(canonicalJson(claim.locator)) ?? "(excerpt unavailable)",
-            locator: claim.locator,
+            source_excerpt: (claim.locator ? byLocator.get(canonicalJson(claim.locator)) : undefined) ?? "(excerpt unavailable)",
+            locator: claim.locator ?? null,
           });
         }
         const decided = await indexStore.exists(`.kdlc/governed/workflow/runs/${index.workflow_id}/reviews/${proposalId}/decision.json`);
         const frontmatter = proposal.concept.after.frontmatter;
         return {
           proposal_id: proposalId,
-          title: frontmatter.title,
+          title: frontmatter.title ?? proposalId,
           type: frontmatter.type ?? null,
           // Omitted status resolves as stable at retrieval, so show that.
           status: frontmatter.status ?? "stable",

--- a/tests/governance/drafting-scaffold.test.mjs
+++ b/tests/governance/drafting-scaffold.test.mjs
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import { KdlcEngine, createLocalProjectEngine, parseCli } from "../../packages/cli/index.mjs";
+import { canonicalJson } from "../../packages/core/index.mjs";
 
 async function completedIngest(engine, root, filename, content) {
   await writeFile(join(root, filename), content);
@@ -399,4 +400,40 @@ test("FEAT-037: publish --show renders the content a reviewer approves — body 
   assert.match(gate.pending[0].next, /--show to read it/);
   // Showing never decides or mutates.
   assert.equal((await engine.execute("publish", {})).pending.length, 1);
+});
+
+test("FEAT-037: --show survives minimal frontmatter — omitted type/status/extraction render, not crash", async () => {
+  const root = await mkdtemp(join(tmpdir(), "kdlc-show-min-"));
+  await new KdlcEngine({ root }).execute("init", { project_id: "show.minimal" });
+  const engine = createLocalProjectEngine({ root });
+  const rights = { license: "LicenseRef-Internal", redistribution: "prohibited", derivative_use: "allowed", commercial_use: "prohibited" };
+  const job = await completedIngest(engine, root, "m.md", "# M\n\n## Fact\n\nBackups run nightly at 01:00 UTC.\n");
+  const scaffold = await engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "LicenseRef-Internal" } });
+  const kit = join(root, ".kdlc/drafting", scaffold.workflow_id);
+  const evidence = JSON.parse(await readFile(join(kit, "normalized-evidence.json"), "utf8"));
+  const template = JSON.parse(await readFile(join(kit, "recording-template.json"), "utf8"));
+  const unit = evidence.units.find(({ text }) => /nightly/.test(text));
+  template.model = { provider: "recorded", model: "t", prompt: "show", recorded_at: template.model.recorded_at };
+  template.claims = [{ id: "clm_bk", text: unit.text, source_id: evidence.source_id, source_hash: evidence.source_hash, locator: unit.locator, extraction: "explicit", status: "accepted", access: { classification: "internal" }, rights }];
+  template.proposals = [{ api_version: "kdlc.dev/concept-proposal/v1alpha1", id: "pr_bk", workflow_id: scaffold.workflow_id, task: "ingest", state: "review_pending", target: { knowledge_base_id: "local.min", revision: "rev-1", subject: "kb://local.min/ops/backups" }, concept: { before: null, after: { frontmatter: { type: "Policy", title: "Backups", description: "d", status: "stable", access: { classification: "internal" }, generated: { by: "kdlc-integrator/0.2.0", at: "2026-08-16T20:30:00Z" }, sources: [{ id: "s", resource: "file:m.md", source_hash: evidence.source_hash, access: { classification: "internal" }, rights }], stale_after: "2030-01-01" }, body: "# Backups\n\nBackups run nightly at 01:00 UTC.\n" } }, claim_ids: ["clm_bk"], claim_decisions: [{ claim_id: "clm_bk", disposition: "accepted", rationale: "explicit" }], created_by: "kdlc-integrator/0.2.0" }];
+  await writeFile(join(kit, "recording-template.json"), JSON.stringify(template));
+  await engine.execute("proposal", { submit: { workflow_id: scaffold.workflow_id } });
+  // Real gate sessions submit frontmatter carrying only title/access/sources
+  // and claims without extraction; strip the stored records to match.
+  const proposalPath = join(root, ".kdlc/governed/workflow/runs", scaffold.workflow_id, "proposals/pr_bk.json");
+  const stored = JSON.parse(await readFile(proposalPath, "utf8"));
+  delete stored.concept.after.frontmatter.type;
+  delete stored.concept.after.frontmatter.status;
+  await writeFile(proposalPath, JSON.stringify(stored));
+  const claimPath = join(root, ".kdlc/governed/workflow/runs", scaffold.workflow_id, "claims/clm_bk.json");
+  const claim = JSON.parse(await readFile(claimPath, "utf8"));
+  delete claim.extraction;
+  await writeFile(claimPath, JSON.stringify(claim));
+
+  const shown = await engine.execute("publish", { proposal_id: "pr_bk", show: true });
+  assert.equal(shown.type, null);
+  assert.equal(shown.status, "stable", "omitted status shows what retrieval resolves it to");
+  assert.equal(shown.claims[0].extraction, null);
+  assert.match(shown.claims[0].source_excerpt, /nightly/);
+  canonicalJson(shown); // the shown packet must render as a JSON envelope
 });

--- a/tests/governance/drafting-scaffold.test.mjs
+++ b/tests/governance/drafting-scaffold.test.mjs
@@ -424,6 +424,7 @@ test("FEAT-037: --show survives minimal frontmatter — omitted type/status/extr
   const stored = JSON.parse(await readFile(proposalPath, "utf8"));
   delete stored.concept.after.frontmatter.type;
   delete stored.concept.after.frontmatter.status;
+  delete stored.concept.after.frontmatter.title;
   await writeFile(proposalPath, JSON.stringify(stored));
   const claimPath = join(root, ".kdlc/governed/workflow/runs", scaffold.workflow_id, "claims/clm_bk.json");
   const claim = JSON.parse(await readFile(claimPath, "utf8"));
@@ -431,6 +432,7 @@ test("FEAT-037: --show survives minimal frontmatter — omitted type/status/extr
   await writeFile(claimPath, JSON.stringify(claim));
 
   const shown = await engine.execute("publish", { proposal_id: "pr_bk", show: true });
+  assert.equal(shown.title, "pr_bk", "omitted title falls back to the proposal id");
   assert.equal(shown.type, null);
   assert.equal(shown.status, "stable", "omitted status shows what retrieval resolves it to");
   assert.equal(shown.claims[0].extraction, null);


### PR DESCRIPTION
Closes #135.

`kdlc publish <id> --show` crashed with `KDLC_CANONICAL_INVALID: Canonical JSON rejects values of type undefined` on any proposal whose frontmatter omits `type`, `status`, or `title` (or whose claims omit `extraction`/`locator`) — the shape real conductor sessions submit. Hit live at the gate for pr_kdlcoverview1 in a dogfooding project.

Root cause: showPacket copied optional fields verbatim; `undefined` survived into the result and the envelope's canonicalJson renderer rejects it. The frontmatter subschema requires no properties, so every one of these fields is legitimately omittable through submit.

Fix: `type`/`extraction`/`locator` default to null, omitted `title` falls back to the proposal id (matching pendingReviews), omitted `status` shows as "stable" — the value retrieval resolves it to.

## Traceability
- Requirement IDs: FEAT-037 (#133)
- Specification section(s): distribution/release/conformance-statement.json — Governed module (publish_request review surface); docs/traceability.json FEAT-037 entry

## Verification
- `npm test` → 304 tests, 304 pass, 0 fail (includes new regression `FEAT-037: --show survives minimal frontmatter` which strips title/type/status/extraction from stored records and asserts the packet still canonicalizes)
- Live smoke against the failing project: `kdlc publish pr_kdlcoverview1 --show --output human` now renders the full packet (previously exit 2, KDLC_CANONICAL_INVALID)
- Independent adversarial review: initial REQUEST_CHANGES (title reachable through legitimate submit) — both findings fixed and regression-locked, see review record comment
