### PR TITLE
fix: --show tolerates minimal frontmatter (#135) [FEAT-038]

### DIFF
--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -14,5 +14,5 @@
   "tools": ["project_init", "project_get", "project_list_mounts", "kb_search", "kb_fetch", "kb_trace", "kb_conflicts", "kb_gaps", "source_excerpt", "job_status", "ingest_start", "proposal_create", "review_submit", "publish_request", "job_cancel"],
   "transports": ["stdio", "streamable-http"],
   "pending_requirements": [],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:2f1562a333535c8b53d639c545ea4e83c452918db015fb6097bf7accc41f7692"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:c5d3b831e534053d7190989d7e3c4175b52072b2098e583e007a90df9adba54c"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -1163,6 +1163,24 @@
           "tests/governance/drafting-scaffold.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-038",
+      "title": "publish --show tolerates minimal frontmatter: shown packets always canonicalize",
+      "issue": 135,
+      "specification_sections": [
+        "14",
+        "25"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "packages/cli/index.mjs"
+        ],
+        "tests": [
+          "tests/governance/drafting-scaffold.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/packages/cli/index.mjs
+++ b/packages/cli/index.mjs
@@ -1343,18 +1343,19 @@ export function createLocalProjectEngine(options = {}) {
           claims.push({
             id: claim.id,
             claim: claim.text,
-            extraction: claim.extraction,
-            source_excerpt: byLocator.get(canonicalJson(claim.locator)) ?? "(excerpt unavailable)",
-            locator: claim.locator,
+            extraction: claim.extraction ?? null,
+            source_excerpt: (claim.locator ? byLocator.get(canonicalJson(claim.locator)) : undefined) ?? "(excerpt unavailable)",
+            locator: claim.locator ?? null,
           });
         }
         const decided = await indexStore.exists(`.kdlc/governed/workflow/runs/${index.workflow_id}/reviews/${proposalId}/decision.json`);
         const frontmatter = proposal.concept.after.frontmatter;
         return {
           proposal_id: proposalId,
-          title: frontmatter.title,
-          type: frontmatter.type,
-          status: frontmatter.status,
+          title: frontmatter.title ?? proposalId,
+          type: frontmatter.type ?? null,
+          // Omitted status resolves as stable at retrieval, so show that.
+          status: frontmatter.status ?? "stable",
           access: frontmatter.access ?? null,
           subject: proposal.target.subject,
           body: proposal.concept.after.body,

--- a/tests/governance/drafting-scaffold.test.mjs
+++ b/tests/governance/drafting-scaffold.test.mjs
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import { KdlcEngine, createLocalProjectEngine, parseCli } from "../../packages/cli/index.mjs";
+import { canonicalJson } from "../../packages/core/index.mjs";
 
 async function completedIngest(engine, root, filename, content) {
   await writeFile(join(root, filename), content);
@@ -399,4 +400,42 @@ test("FEAT-037: publish --show renders the content a reviewer approves — body 
   assert.match(gate.pending[0].next, /--show to read it/);
   // Showing never decides or mutates.
   assert.equal((await engine.execute("publish", {})).pending.length, 1);
+});
+
+test("FEAT-037: --show survives minimal frontmatter — omitted type/status/extraction render, not crash", async () => {
+  const root = await mkdtemp(join(tmpdir(), "kdlc-show-min-"));
+  await new KdlcEngine({ root }).execute("init", { project_id: "show.minimal" });
+  const engine = createLocalProjectEngine({ root });
+  const rights = { license: "LicenseRef-Internal", redistribution: "prohibited", derivative_use: "allowed", commercial_use: "prohibited" };
+  const job = await completedIngest(engine, root, "m.md", "# M\n\n## Fact\n\nBackups run nightly at 01:00 UTC.\n");
+  const scaffold = await engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "LicenseRef-Internal" } });
+  const kit = join(root, ".kdlc/drafting", scaffold.workflow_id);
+  const evidence = JSON.parse(await readFile(join(kit, "normalized-evidence.json"), "utf8"));
+  const template = JSON.parse(await readFile(join(kit, "recording-template.json"), "utf8"));
+  const unit = evidence.units.find(({ text }) => /nightly/.test(text));
+  template.model = { provider: "recorded", model: "t", prompt: "show", recorded_at: template.model.recorded_at };
+  template.claims = [{ id: "clm_bk", text: unit.text, source_id: evidence.source_id, source_hash: evidence.source_hash, locator: unit.locator, extraction: "explicit", status: "accepted", access: { classification: "internal" }, rights }];
+  template.proposals = [{ api_version: "kdlc.dev/concept-proposal/v1alpha1", id: "pr_bk", workflow_id: scaffold.workflow_id, task: "ingest", state: "review_pending", target: { knowledge_base_id: "local.min", revision: "rev-1", subject: "kb://local.min/ops/backups" }, concept: { before: null, after: { frontmatter: { type: "Policy", title: "Backups", description: "d", status: "stable", access: { classification: "internal" }, generated: { by: "kdlc-integrator/0.2.0", at: "2026-08-16T20:30:00Z" }, sources: [{ id: "s", resource: "file:m.md", source_hash: evidence.source_hash, access: { classification: "internal" }, rights }], stale_after: "2030-01-01" }, body: "# Backups\n\nBackups run nightly at 01:00 UTC.\n" } }, claim_ids: ["clm_bk"], claim_decisions: [{ claim_id: "clm_bk", disposition: "accepted", rationale: "explicit" }], created_by: "kdlc-integrator/0.2.0" }];
+  await writeFile(join(kit, "recording-template.json"), JSON.stringify(template));
+  await engine.execute("proposal", { submit: { workflow_id: scaffold.workflow_id } });
+  // Real gate sessions submit frontmatter carrying only title/access/sources
+  // and claims without extraction; strip the stored records to match.
+  const proposalPath = join(root, ".kdlc/governed/workflow/runs", scaffold.workflow_id, "proposals/pr_bk.json");
+  const stored = JSON.parse(await readFile(proposalPath, "utf8"));
+  delete stored.concept.after.frontmatter.type;
+  delete stored.concept.after.frontmatter.status;
+  delete stored.concept.after.frontmatter.title;
+  await writeFile(proposalPath, JSON.stringify(stored));
+  const claimPath = join(root, ".kdlc/governed/workflow/runs", scaffold.workflow_id, "claims/clm_bk.json");
+  const claim = JSON.parse(await readFile(claimPath, "utf8"));
+  delete claim.extraction;
+  await writeFile(claimPath, JSON.stringify(claim));
+
+  const shown = await engine.execute("publish", { proposal_id: "pr_bk", show: true });
+  assert.equal(shown.title, "pr_bk", "omitted title falls back to the proposal id");
+  assert.equal(shown.type, null);
+  assert.equal(shown.status, "stable", "omitted status shows what retrieval resolves it to");
+  assert.equal(shown.claims[0].extraction, null);
+  assert.match(shown.claims[0].source_excerpt, /nightly/);
+  canonicalJson(shown); // the shown packet must render as a JSON envelope
 });


### PR DESCRIPTION
Closes #135.

`kdlc publish <id> --show` crashed with `KDLC_CANONICAL_INVALID: Canonical JSON rejects values of type undefined` on any proposal whose frontmatter omits `title`, `type`, or `status` (or whose claims omit `extraction`/`locator`) — the shape real conductor sessions submit, since the concept-proposal frontmatter subschema requires no properties. Hit live at the human gate for pr_kdlcoverview1.

Root cause: showPacket copied optional fields verbatim; `undefined` survived into the result and the envelope's canonicalJson renderer rejects it.

Fix: `type`/`extraction`/`locator` default to null, omitted `title` falls back to the proposal id (matching pendingReviews), omitted `status` shows as "stable" — the value retrieval resolves it to. Registered as FEAT-038.

Replaces #136 (same diff; rebuilt on a branch bound to issue #135 for traceability). Independent adversarial review ran there: initial REQUEST_CHANGES — reviewer reproduced the crash through a legitimate submit with omitted `title`; both findings fixed and regression-locked. See PR #136 comments for the full review and owner exception records.

## Traceability
- Requirement IDs: FEAT-038
- Specification section(s): sections 14 and 25 (governed review surface and publication gate)

## Verification
Commands and results:
```text
npm test → tests 304, pass 304, fail 0
  (includes new regression "FEAT-037: --show survives minimal frontmatter" stripping
   title/type/status/extraction from stored records; asserts canonicalJson(shown) succeeds)
node scripts/verify-governance.mjs → ok (49 requirements, 5 gates)
Live smoke in the failing project: kdlc publish pr_kdlcoverview1 --show --output human
  → renders full packet (previously exit 2, KDLC_CANONICAL_INVALID)
```
