### PR TITLE
fix: federation errors pass through the envelope (#138) [FEAT-039]

### DIFF
--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -14,5 +14,5 @@
   "tools": ["project_init", "project_get", "project_list_mounts", "kb_search", "kb_fetch", "kb_trace", "kb_conflicts", "kb_gaps", "source_excerpt", "job_status", "ingest_start", "proposal_create", "review_submit", "publish_request", "job_cancel"],
   "transports": ["stdio", "streamable-http"],
   "pending_requirements": [],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:c5d3b831e534053d7190989d7e3c4175b52072b2098e583e007a90df9adba54c"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:32df210f8be8195112cb0782d4fe7b39703d8cf60366c1f962ecd921417b2417"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -1181,6 +1181,24 @@
           "tests/governance/drafting-scaffold.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-039",
+      "title": "Federation refusals pass through the CLI envelope with their real code",
+      "issue": 138,
+      "specification_sections": [
+        "20",
+        "25"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "packages/cli/index.mjs"
+        ],
+        "tests": [
+          "tests/governance/cli-hints.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/packages/cli/index.mjs
+++ b/packages/cli/index.mjs
@@ -216,7 +216,7 @@ export class KdlcEngine {
       const coded =
         typeof error?.code === "string" &&
         error.code.startsWith("KDLC_") &&
-        ["GovernanceError", "AgentPolicyError"].includes(error?.name);
+        ["GovernanceError", "AgentPolicyError", "FederationError"].includes(error?.name);
       // Exit classes are a stable §25 contract: conflicts and missing
       // dependencies must not masquerade as policy refusals.
       const codedClass = !coded

--- a/packages/federation/src/resolver.mjs
+++ b/packages/federation/src/resolver.mjs
@@ -89,7 +89,7 @@ async function runGitBytes(args, cwd) {
 }
 
 function gitUrl(uri) {
-  if (!uri.startsWith("git+")) federationFail("KDLC_MOUNT_SCHEME", `Unsupported mount URI scheme: ${uri}`);
+  if (!uri.startsWith("git+")) federationFail("KDLC_MOUNT_SCHEME", `Unsupported mount URI scheme: ${uri.split(":", 1)[0]}`);
   const value = uri.slice(4);
   if (!/^(?:file|https|ssh):\/\//.test(value)) federationFail("KDLC_MOUNT_SCHEME", "Git mounts require git+file, git+https, or git+ssh");
   let parsed; try { parsed = new URL(value); } catch { federationFail("KDLC_MOUNT_SCHEME", "Git mount URI is invalid"); }

--- a/tests/governance/cli-hints.test.mjs
+++ b/tests/governance/cli-hints.test.mjs
@@ -78,6 +78,14 @@ test("FEAT-031: governed refusals surface their real code and details through th
   assert.ok(!JSON.stringify(masked).includes("secret internals"));
 });
 
+test("FEAT-031: federation refusals pass through with their real code instead of masking as internal (#138)", async () => {
+  const { FederationError } = await import("../../packages/federation/src/errors.mjs");
+  const engine = new KdlcEngine({ handlers: { status: () => { throw new FederationError("KDLC_PROJECT_INVALID", "Project manifest is invalid", { contract: [{ message: "must have required property 'priority'" }] }); } } });
+  const envelope = await engine.envelope("status", {});
+  assert.equal(envelope.error.code, "KDLC_PROJECT_INVALID");
+  assert.match(JSON.stringify(envelope.error.details), /priority/, "the actionable detail reaches the user");
+});
+
 test("FEAT-031: coded refusals keep the exit-class taxonomy and never break the envelope", async () => {
   const { GovernanceError } = await import("../../packages/governance/index.mjs");
   const make = (code, extra = {}) => new KdlcEngine({ handlers: { status: () => { throw Object.assign(new GovernanceError(code, "m"), extra); } } });

--- a/tests/governance/cli-hints.test.mjs
+++ b/tests/governance/cli-hints.test.mjs
@@ -86,6 +86,20 @@ test("FEAT-031: federation refusals pass through with their real code instead of
   assert.match(JSON.stringify(envelope.error.details), /priority/, "the actionable detail reaches the user");
 });
 
+test("FEAT-039: a mistyped mount URI never echoes an embedded credential through the envelope (review MEDIUM)", async () => {
+  const { mkdtemp } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const { FederationResolver } = await import("../../packages/federation/src/resolver.mjs");
+  const resolver = new FederationResolver({ projectRoot: await mkdtemp(join(tmpdir(), "kdlc-scheme-")) });
+  for (const uri of ["git+ftp://user:supersecrettoken@host/repo.git", "https://user:supersecrettoken@host/repo.git"]) {
+    await assert.rejects(
+      resolver.resolveMount({ name: "oops", uri, ref: "main", mode: "read-only" }),
+      (error) => typeof error.code === "string" && error.code.startsWith("KDLC_") && !error.message.includes("supersecrettoken") && !JSON.stringify(error.details ?? {}).includes("supersecrettoken")
+    );
+  }
+});
+
 test("FEAT-031: coded refusals keep the exit-class taxonomy and never break the envelope", async () => {
   const { GovernanceError } = await import("../../packages/governance/index.mjs");
   const make = (code, extra = {}) => new KdlcEngine({ handlers: { status: () => { throw Object.assign(new GovernanceError(code, "m"), extra); } } });


### PR DESCRIPTION
Closes #138.

While live-smoking a `git+file://` knowledge-base mount, an invalid manifest (`KDLC_PROJECT_INVALID: must have required property 'priority'`) reached the user as `KDLC_INTERNAL: Internal operation failure`. The FEAT-031 coded-error passthrough listed only `GovernanceError` and `AgentPolicyError`; every `FederationError` (mount schemes, git resolution, cache drift, project validation) was scrubbed to internal, hiding the actionable message.

Fix: `FederationError` joins the passthrough allowlist. It inherits the existing suffix exit taxonomy and detail canonicalization; unknown errors stay scrubbed.

## Traceability
- Requirement IDs: FEAT-039
- Specification section(s): sections 20 and 25 (federation mount resolution; CLI envelope and exit taxonomy)

## Verification
Commands and results:
```text
npm test → tests 305, pass 305, fail 0 (new FEAT-031/#138 regression: FederationError code and
  details reach the envelope; unknown errors remain KDLC_INTERNAL)
node scripts/verify-governance.mjs → Governance verified: 51 traceable requirements and 5 gates
Live smoke: consumer project with git+file:// mount missing `priority` now reports
  KDLC_PROJECT_INVALID with the contract detail (previously KDLC_INTERNAL)
```
