### PR TITLE
fix: kiro-ide setup installs the protective tier (#142) [FEAT-041]

### DIFF
--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -14,5 +14,5 @@
   "tools": ["project_init", "project_get", "project_list_mounts", "kb_search", "kb_fetch", "kb_trace", "kb_conflicts", "kb_gaps", "source_excerpt", "job_status", "ingest_start", "proposal_create", "review_submit", "publish_request", "job_cancel"],
   "transports": ["stdio", "streamable-http"],
   "pending_requirements": [],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:803690894adc2a3d1f841cddee239d9921388444532bd27de74ba68bd76d3db7"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:3ce9c064468bf1263b33d1d930e1de0f03e078d6b9197028c9a6e59cd9f9a287"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -1218,6 +1218,24 @@
           "tests/governance/human-surfaces.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-041",
+      "title": "kiro-ide setup installs the full protective tier with rewritten paths",
+      "issue": 142,
+      "specification_sections": [
+        "5.7",
+        "36"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "packages/cli/setup.mjs"
+        ],
+        "tests": [
+          "tests/governance/human-surfaces.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/packages/cli/setup.mjs
+++ b/packages/cli/setup.mjs
@@ -32,10 +32,16 @@ async function kiroSurface(harness, commands) {
     files.set(`.kiro/agents/${agent.role}.md`, renderKiroAgentPrompt(agent));
   }
   const distribution = resolve(packageRoot, `distribution/${harness}`);
-  files.set(".kiro/kdlc/AGENTS.md", await readFile(resolve(distribution, "AGENTS.md"), "utf8"));
+  // Copied prose references the checkout-relative runner; installed projects
+  // must name the absolute one or the docs contradict the permission gate.
+  const rebind = (text) => text.replaceAll(`distribution/${harness}/run.mjs`, runner);
+  files.set(".kiro/kdlc/AGENTS.md", rebind(await readFile(resolve(distribution, "AGENTS.md"), "utf8")));
   for (const guide of ["asking-questions", "bringing-knowledge-in", "connecting-remote-sources", "keeping-it-healthy", "review-and-publish", "when-something-is-wrong"]) {
-    files.set(`.kiro/kdlc/guides/${guide}.md`, await readFile(resolve(distribution, `guides/${guide}.md`), "utf8"));
+    files.set(`.kiro/kdlc/guides/${guide}.md`, rebind(await readFile(resolve(distribution, `guides/${guide}.md`), "utf8")));
   }
+  // The FEAT-035 front-door skill is generated outside CLI_COMMANDS — install
+  // it explicitly, rebound like every other skill.
+  files.set(".kiro/skills/kdlc-start/SKILL.md", rebind(await readFile(resolve(distribution, ".kiro/skills/kdlc-start/SKILL.md"), "utf8")));
   const instructions = [`Kiro skills invoke the governed runner at ${runner}; keep this package installed at that path (reinstall/upgrade re-runs setup).`];
   if (harness === "kiro-ide") {
     // The protective parity tier (FEAT-040): dual-registered hooks and the
@@ -47,7 +53,7 @@ async function kiroSurface(harness, commands) {
     door.toolsSettings.execute_bash.allowedCommands = [`node ${escapeRegex(runner)} [a-z-]+( [A-Za-z0-9@=_"\\[\\],{}:. /-]*)?`];
     door.resources = ["file://.kiro/kdlc/AGENTS.md", "file://.kiro/kdlc/guides/*.md"];
     files.set(".kiro/agents/kdlc.json", `${canonicalJson(door)}\n`);
-    files.set(".kiro/agents/kdlc.md", await readFile(resolve(distribution, ".kiro/agents/kdlc.md"), "utf8"));
+    files.set(".kiro/agents/kdlc.md", rebind(await readFile(resolve(distribution, ".kiro/agents/kdlc.md"), "utf8")));
     instructions.push("Kiro IDE hooks installed (dual-registered for 0.12 and 1.x): session orientation and a guard blocking direct edits to governed knowledge state.");
   }
   return { files, instructions };

--- a/packages/cli/setup.mjs
+++ b/packages/cli/setup.mjs
@@ -1,7 +1,7 @@
 // FEAT-016 (#82): materialize a harness surface into a user project with
 // runner paths resolved from this installed package or checkout, so the
 // installed files work from any directory (no run-from-checkout constraint).
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -13,7 +13,7 @@ export const SETUP_TOOLS = Object.freeze(["claude-code", "codex", "kiro", "kiro-
 
 const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 
-function kiroSurface(harness, commands) {
+async function kiroSurface(harness, commands) {
   const runner = resolve(packageRoot, `distribution/${harness}/run.mjs`);
   const files = new Map();
   for (const command of commands) {
@@ -25,10 +25,32 @@ function kiroSurface(harness, commands) {
   for (const agent of AGENT_DEFINITIONS) {
     const manifest = renderKiroAgentManifest(agent, { harness });
     if (manifest.toolsSettings) manifest.toolsSettings.execute_bash.allowedCommands = [`node ${escapeRegex(runner)} [a-z-]+( [A-Za-z0-9@=_"\\[\\],{}:. /-]*)?`];
+    // Installed projects keep the K-DLC context under .kiro/kdlc/ so setup
+    // never collides with the project's own root files (FEAT-040).
+    manifest.resources = [`file://.kiro/agents/${agent.role}.md`, "file://.kiro/kdlc/AGENTS.md", "file://.kiro/kdlc/guides/*.md"];
     files.set(`.kiro/agents/${agent.role}.json`, `${canonicalJson(manifest)}\n`);
     files.set(`.kiro/agents/${agent.role}.md`, renderKiroAgentPrompt(agent));
   }
-  return { files, instructions: [`Kiro skills invoke the governed runner at ${runner}; keep this package installed at that path (reinstall/upgrade re-runs setup).`] };
+  const distribution = resolve(packageRoot, `distribution/${harness}`);
+  files.set(".kiro/kdlc/AGENTS.md", await readFile(resolve(distribution, "AGENTS.md"), "utf8"));
+  for (const guide of ["asking-questions", "bringing-knowledge-in", "connecting-remote-sources", "keeping-it-healthy", "review-and-publish", "when-something-is-wrong"]) {
+    files.set(`.kiro/kdlc/guides/${guide}.md`, await readFile(resolve(distribution, `guides/${guide}.md`), "utf8"));
+  }
+  const instructions = [`Kiro skills invoke the governed runner at ${runner}; keep this package installed at that path (reinstall/upgrade re-runs setup).`];
+  if (harness === "kiro-ide") {
+    // The protective parity tier (FEAT-040): dual-registered hooks and the
+    // kdlc front-door agent, with runner paths resolved to this package.
+    for (const name of ["kdlc-orient.mjs", "kdlc-guard.mjs", "kdlc-orient.kiro.hook", "kdlc-guard.kiro.hook", "kdlc-orient.json", "kdlc-guard.json"]) {
+      files.set(`.kiro/hooks/${name}`, await readFile(resolve(distribution, `.kiro/hooks/${name}`), "utf8"));
+    }
+    const door = JSON.parse(await readFile(resolve(distribution, ".kiro/agents/kdlc.json"), "utf8"));
+    door.toolsSettings.execute_bash.allowedCommands = [`node ${escapeRegex(runner)} [a-z-]+( [A-Za-z0-9@=_"\\[\\],{}:. /-]*)?`];
+    door.resources = ["file://.kiro/kdlc/AGENTS.md", "file://.kiro/kdlc/guides/*.md"];
+    files.set(".kiro/agents/kdlc.json", `${canonicalJson(door)}\n`);
+    files.set(".kiro/agents/kdlc.md", await readFile(resolve(distribution, ".kiro/agents/kdlc.md"), "utf8"));
+    instructions.push("Kiro IDE hooks installed (dual-registered for 0.12 and 1.x): session orientation and a guard blocking direct edits to governed knowledge state.");
+  }
+  return { files, instructions };
 }
 
 function codexSurface(commands) {
@@ -70,7 +92,7 @@ export async function runSetup({ tool, project }) {
       instructions.push("The plugin includes session hooks: an orientation note at session start and a guard that blocks direct edits to governed knowledge-bases/ and workflow/ files (use kdlc proposal / kdlc reconcile-edits instead). Plain-language workflow guides are in its guides/ directory.");
       continue;
     }
-    const surface = requested === "codex" ? codexSurface(commands) : requested === "mcp" ? mcpSurface() : kiroSurface(requested, commands);
+    const surface = requested === "codex" ? codexSurface(commands) : requested === "mcp" ? mcpSurface() : await kiroSurface(requested, commands);
     for (const [relative, content] of surface.files) {
       const path = resolve(target, relative);
       await mkdir(dirname(path), { recursive: true });

--- a/tests/governance/human-surfaces.test.mjs
+++ b/tests/governance/human-surfaces.test.mjs
@@ -175,3 +175,26 @@ test("FEAT-040: the Kiro IDE surface carries the protective parity tier — hook
     }
   }
 });
+
+test("FEAT-040: kiro-ide setup installs the full protective tier into a project (#142)", async () => {
+  const { mkdtemp } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { runSetup } = await import("../../packages/cli/setup.mjs");
+  const target = await mkdtemp(join(tmpdir(), "kdlc-setup-kiro-"));
+  const result = await runSetup({ tool: "kiro-ide", project: target });
+  for (const file of [
+    ".kiro/agents/kdlc.json", ".kiro/agents/kdlc.md",
+    ".kiro/hooks/kdlc-guard.mjs", ".kiro/hooks/kdlc-guard.kiro.hook", ".kiro/hooks/kdlc-guard.json",
+    ".kiro/hooks/kdlc-orient.mjs", ".kiro/hooks/kdlc-orient.kiro.hook", ".kiro/hooks/kdlc-orient.json",
+    ".kiro/kdlc/AGENTS.md", ".kiro/kdlc/guides/review-and-publish.md"
+  ]) {
+    assert.ok(result.files.includes(file), `setup installs ${file}`);
+  }
+  // Installed manifests bind the runner absolutely and keep context under
+  // .kiro/kdlc/ so setup never collides with the project's own root files.
+  const door = JSON.parse(await readFile(join(target, ".kiro/agents/kdlc.json"), "utf8"));
+  assert.match(door.toolsSettings.execute_bash.allowedCommands[0], /^node \/.*run\\\.mjs /);
+  assert.deepEqual(door.resources, ["file://.kiro/kdlc/AGENTS.md", "file://.kiro/kdlc/guides/*.md"]);
+  const roleManifest = JSON.parse(await readFile(join(target, ".kiro/agents/conductor.json"), "utf8"));
+  assert.deepEqual(roleManifest.resources, ["file://.kiro/agents/conductor.md", "file://.kiro/kdlc/AGENTS.md", "file://.kiro/kdlc/guides/*.md"]);
+});

--- a/tests/governance/human-surfaces.test.mjs
+++ b/tests/governance/human-surfaces.test.mjs
@@ -186,9 +186,15 @@ test("FEAT-040: kiro-ide setup installs the full protective tier into a project 
     ".kiro/agents/kdlc.json", ".kiro/agents/kdlc.md",
     ".kiro/hooks/kdlc-guard.mjs", ".kiro/hooks/kdlc-guard.kiro.hook", ".kiro/hooks/kdlc-guard.json",
     ".kiro/hooks/kdlc-orient.mjs", ".kiro/hooks/kdlc-orient.kiro.hook", ".kiro/hooks/kdlc-orient.json",
-    ".kiro/kdlc/AGENTS.md", ".kiro/kdlc/guides/review-and-publish.md"
+    ".kiro/kdlc/AGENTS.md", ".kiro/kdlc/guides/review-and-publish.md", ".kiro/skills/kdlc-start/SKILL.md"
   ]) {
     assert.ok(result.files.includes(file), `setup installs ${file}`);
+  }
+  // Installed prose must name the absolute runner, never the checkout-relative
+  // path its own permission gate would deny (review HIGH).
+  for (const doc of [".kiro/agents/kdlc.md", ".kiro/kdlc/AGENTS.md", ".kiro/skills/kdlc-start/SKILL.md"]) {
+    const text = await readFile(join(target, doc), "utf8");
+    assert.ok(!text.includes('"distribution/kiro-ide/run.mjs"'), `${doc} names the installed runner`);
   }
   // Installed manifests bind the runner absolutely and keep context under
   // .kiro/kdlc/ so setup never collides with the project's own root files.


### PR DESCRIPTION
Closes #142.

Reported live while testing Kiro IDE: `kdlc setup kiro-ide <project>` installed only agents and skills (39 files) — none of FEAT-040's protective tier reached installed projects. Setup now installs the dual-registered hooks (six files), the `kdlc` front-door agent with its runner path resolved absolutely into the installed package, and the harness contract + six plain-language guides under `.kiro/kdlc/` so nothing collides with the project's own root files; every agent manifest's `resources` are rewritten to the installed locations. Verified live on the reporting project: 39 → 54 files.

## Traceability
- Requirement IDs: FEAT-041
- Specification section(s): sections 5.7 and 36 (harness capability confinement; distribution surfaces)

## Verification
Commands and results:
```text
npm test → tests 308, pass 308, fail 0 (new regression: setup file set, absolute runner binding,
  .kiro/kdlc/ resource rewrites for front door and role manifests)
node scripts/verify-governance.mjs → Governance verified: 53 traceable requirements and 5 gates
Live: kdlc setup kiro-ide <project> → 54 files incl. hooks/front door/AGENTS.md/guides
```
