### PR TITLE
fix: partial sources scaffold with honest coverage (#144) [FEAT-042]

### DIFF
--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -14,5 +14,5 @@
   "tools": ["project_init", "project_get", "project_list_mounts", "kb_search", "kb_fetch", "kb_trace", "kb_conflicts", "kb_gaps", "source_excerpt", "job_status", "ingest_start", "proposal_create", "review_submit", "publish_request", "job_cancel"],
   "transports": ["stdio", "streamable-http"],
   "pending_requirements": [],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:3ce9c064468bf1263b33d1d930e1de0f03e078d6b9197028c9a6e59cd9f9a287"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:dbc0870da719a47790f6b675c7d25ebb1b26f1799d0dbf822331b825b91356d0"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -1236,6 +1236,24 @@
           "tests/governance/human-surfaces.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-042",
+      "title": "Partial normalizations scaffold with honest coverage; sparse CLI input never masks its error",
+      "issue": 144,
+      "specification_sections": [
+        "14",
+        "25"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "packages/cli/index.mjs"
+        ],
+        "tests": [
+          "tests/governance/drafting-scaffold.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/packages/cli/index.mjs
+++ b/packages/cli/index.mjs
@@ -193,7 +193,10 @@ export class KdlcEngine {
     return JSON.parse(await readFile(path, "utf8"));
   }
   correlation(operation, input) {
-    return `cor_${digest({ operation, input }).slice(7, 23)}`;
+    // Strip undefined values first: correlation runs before the envelope's
+    // error handling, so a sparse input must never explode the whole CLI
+    // into KDLC_CANONICAL_INVALID (#144). Well-formed inputs hash unchanged.
+    return `cor_${digest(JSON.parse(JSON.stringify({ operation, input: input ?? null }))).slice(7, 23)}`;
   }
   async envelope(operation, input = {}) {
     const correlation_id = this.correlation(operation, input);
@@ -875,8 +878,8 @@ export function parseCli(argv) {
     } else {
       input.scaffold = {
         job_id: flag("--scaffold"),
-        access: flag("--access"),
-        license: flag("--license"),
+        ...(flag("--access") !== undefined ? { access: flag("--access") } : {}),
+        ...(flag("--license") !== undefined ? { license: flag("--license") } : {}),
         ...(flag("--workflow") ? { workflow_id: flag("--workflow") } : {}),
         ...(flag("--source") !== undefined ? { source: flag("--source") } : {}),
         ...(positionals.includes("--all-sources") ? { all_sources: true } : {}),
@@ -1551,22 +1554,32 @@ export function createLocalProjectEngine(options = {}) {
     if (!existsSync(jobPath)) throw missing("Requested job is unavailable");
     const job = JSON.parse(readFileSync(jobPath, "utf8"));
     if (job.operation !== "ingest" || job.state !== "completed") throw inputError(`scaffold needs a completed ingest job; ${jobId} is ${job.operation}/${job.state}`);
-    const artifacts = (job.result?.normalized ?? []).filter((entry) => entry?.manifest?.status === "complete");
+    // Partial normalizations (bounded intake of large sources) are draftable:
+    // their coverage is disclosed in the kit instead of the source being
+    // silently dropped (#144). Anything else is reported, never vanished.
+    const allEntries = job.result?.normalized ?? [];
+    const artifacts = allEntries.filter((entry) => ["complete", "partial"].includes(entry?.manifest?.status));
+    const undraftable = allEntries
+      .map((entry, index) => ({ entry, index }))
+      .filter(({ entry }) => !["complete", "partial"].includes(entry?.manifest?.status))
+      .map(({ entry, index }) => ({ source: job.request?.sources?.[index] ?? entry?.manifest?.source_id ?? `source ${index}`, status: entry?.manifest?.status ?? "unknown" }));
     if (artifacts.length === 0) throw inputError("the job's normalization did not complete — nothing to draft from");
     // Fail closed on multi-document jobs: silently drafting only the first
     // file loses the rest. Each document gets its own workflow and kit.
+    const originalIndex = (artifact) => allEntries.indexOf(artifact);
     let selection;
     if (allSources) {
       if (requestedWorkflow) throw inputError("--workflow cannot combine with --all-sources (each document gets its own workflow)");
-      selection = artifacts.map((artifact, index) => ({ artifact, index }));
+      selection = artifacts.map((artifact) => ({ artifact, index: originalIndex(artifact) }));
     } else if (source !== undefined) {
       const index = Number(source);
-      if (!Number.isInteger(index) || index < 0 || index >= artifacts.length) throw inputError(`--source must be 0..${artifacts.length - 1} for this job`);
-      selection = [{ artifact: artifacts[index], index }];
+      if (!Number.isInteger(index) || index < 0 || index >= allEntries.length) throw inputError(`--source must be 0..${allEntries.length - 1} for this job`);
+      if (!artifacts.includes(allEntries[index])) throw inputError(`source ${index} did not normalize to a draftable state (${allEntries[index]?.manifest?.status ?? "unknown"})`);
+      selection = [{ artifact: allEntries[index], index }];
     } else if (artifacts.length === 1) {
-      selection = [{ artifact: artifacts[0], index: 0 }];
+      selection = [{ artifact: artifacts[0], index: originalIndex(artifacts[0]) }];
     } else {
-      const menu = artifacts.map((artifact, index) => `${index}: ${job.request?.sources?.[index] ?? artifact.manifest.source_id} (${artifact.units.length} units)`).join("; ");
+      const menu = artifacts.map((artifact) => `${originalIndex(artifact)}: ${job.request?.sources?.[originalIndex(artifact)] ?? artifact.manifest.source_id} (${artifact.units.length} units${artifact.manifest.status === "partial" ? ", partial coverage" : ""})`).join("; ");
       throw inputError(`this job ingested ${artifacts.length} documents — pick one with --source <n> or scaffold every document with --all-sources. Sources: ${menu}`);
     }
     let sliceBounds = null;
@@ -1596,11 +1609,16 @@ export function createLocalProjectEngine(options = {}) {
       return { job_id: jobId, scaffolds: [], skipped, next: "every document is already scaffolded — fill the kits and submit with kdlc proposal --submit <workflow-id>" };
     }
     return withDefaultsNote(
-      selection.length === 1 ? scaffolded[0] : { job_id: jobId, scaffolds: scaffolded, ...(skipped.length ? { skipped } : {}), next: "fill each kit's recording template, then submit each with kdlc proposal --submit <workflow-id>" },
+      selection.length === 1
+        ? { ...scaffolded[0], ...(undraftable.length ? { undraftable_sources: undraftable } : {}) }
+        : { job_id: jobId, scaffolds: scaffolded, ...(skipped.length ? { skipped } : {}), ...(undraftable.length ? { undraftable_sources: undraftable } : {}), next: "fill each kit's recording template, then submit each with kdlc proposal --submit <workflow-id>" },
       usedDefaults, access, license,
     );
   };
   const scaffoldOneSource = async ({ artifact, workflowId, access, license, sliceBounds, sourceName }) => {
+    const coverageNote = artifact.manifest.status === "partial"
+      ? `partial coverage: bounded intake emitted ${artifact.units.length} units (coverage ${JSON.stringify(artifact.manifest.coverage ?? {})}); claims must not present this as a full read of the source`
+      : null;
     let units = artifact.units.filter((unit) => typeof unit.text === "string" && unit.text.trim().length > 0)
       .map((unit) => ({ locator: unit.locator, text: unit.text }));
     const totalUnits = units.length;
@@ -1624,8 +1642,8 @@ export function createLocalProjectEngine(options = {}) {
         authority: principal.actor,
         access: { classification: access },
         rights,
-        extraction_quality: "high",
-        warnings: [],
+        extraction_quality: artifact.manifest.status === "partial" ? "medium" : "high",
+        warnings: coverageNote ? [coverageNote] : [],
       }],
       // The base profile requires exactly this sensor; its check (every claim
       // anchored to a persisted normalized unit) is re-executed deterministically
@@ -1661,6 +1679,7 @@ export function createLocalProjectEngine(options = {}) {
     await writeFile(resolve(kitDirectory, "README.md"), [
       `# Drafting kit — workflow ${workflowId}`,
       "",
+      ...(coverageNote ? [`> **${coverageNote}**`, ""] : []),
       "Fill `recording-template.json`, then submit it — the runtime verifies every hash and anchor:",
       "",
       "1. Add claims: each needs `id` matching clm_<lowercase letters and digits only>, `text`, `source_id` and",
@@ -1701,6 +1720,7 @@ export function createLocalProjectEngine(options = {}) {
       review_context: contextRecordPath,
       kit: [".kdlc/drafting/" + workflowId + "/README.md", ".kdlc/drafting/" + workflowId + "/recording-template.json", ".kdlc/drafting/" + workflowId + "/normalized-evidence.json", ".kdlc/drafting/" + workflowId + "/locators.json"],
       units: units.length,
+      ...(coverageNote ? { coverage: coverageNote } : {}),
       ...(sliceBounds ? { slice: `${sliceBounds[0]}-${sliceBounds[1]} of ${totalUnits} text units` } : {}),
       access: { classification: access },
       rights,

--- a/packages/cli/index.mjs
+++ b/packages/cli/index.mjs
@@ -1606,7 +1606,7 @@ export function createLocalProjectEngine(options = {}) {
       }
     }
     if (allSources && scaffolded.length === 0 && skipped.length > 0) {
-      return { job_id: jobId, scaffolds: [], skipped, next: "every document is already scaffolded — fill the kits and submit with kdlc proposal --submit <workflow-id>" };
+      return { job_id: jobId, scaffolds: [], skipped, ...(undraftable.length ? { undraftable_sources: undraftable } : {}), next: "every document is already scaffolded — fill the kits and submit with kdlc proposal --submit <workflow-id>" };
     }
     return withDefaultsNote(
       selection.length === 1
@@ -1617,7 +1617,7 @@ export function createLocalProjectEngine(options = {}) {
   };
   const scaffoldOneSource = async ({ artifact, workflowId, access, license, sliceBounds, sourceName }) => {
     const coverageNote = artifact.manifest.status === "partial"
-      ? `partial coverage: bounded intake emitted ${artifact.units.length} units (coverage ${JSON.stringify(artifact.manifest.coverage ?? {})}); claims must not present this as a full read of the source`
+      ? `partial coverage: bounded intake — ${artifact.units.length} normalized units are draftable, coverage record ${JSON.stringify(artifact.manifest.coverage ?? {})}; claims must not present this as a full read of the source`
       : null;
     let units = artifact.units.filter((unit) => typeof unit.text === "string" && unit.text.trim().length > 0)
       .map((unit) => ({ locator: unit.locator, text: unit.text }));

--- a/tests/governance/drafting-scaffold.test.mjs
+++ b/tests/governance/drafting-scaffold.test.mjs
@@ -461,7 +461,7 @@ test("FEAT-042: partial normalizations scaffold with honest coverage instead of 
   const result = await engine.execute("proposal", { scaffold: { job_id: job.id, all_sources: true, access: "internal", license: "LicenseRef-Internal" } });
   assert.equal(result.scaffolds.length, 2, "complete AND partial sources scaffold");
   const partial = result.scaffolds.find(({ source }) => source === "forecast.csv");
-  assert.match(partial.coverage, /partial coverage: bounded intake/, "the kit result discloses bounded coverage");
+  assert.match(partial.coverage, /partial coverage: bounded intake — \d+ normalized units are draftable/, "the kit result discloses bounded coverage");
   assert.match(await readFile(join(root, ".kdlc/drafting", partial.workflow_id, "README.md"), "utf8"), /partial coverage/, "the kit README leads with the disclosure");
   const { context } = JSON.parse(await readFile(join(root, ".kdlc/governed/review-contexts", `${partial.workflow_id}.json`), "utf8"));
   assert.equal(context.evidence[0].extraction_quality, "medium");

--- a/tests/governance/drafting-scaffold.test.mjs
+++ b/tests/governance/drafting-scaffold.test.mjs
@@ -439,3 +439,50 @@ test("FEAT-037: --show survives minimal frontmatter — omitted type/status/extr
   assert.match(shown.claims[0].source_excerpt, /nightly/);
   canonicalJson(shown); // the shown packet must render as a JSON envelope
 });
+
+test("FEAT-042: partial normalizations scaffold with honest coverage instead of vanishing (#144)", async () => {
+  const root = await mkdtemp(join(tmpdir(), "kdlc-partial-"));
+  await new KdlcEngine({ root }).execute("init", { project_id: "partial.fixture" });
+  const engine = createLocalProjectEngine({ root });
+  const job = await completedIngest(engine, root, "big.md", "# Big\n\n## A\n\nRow one is retained.\n\n## B\n\nRow two is retained.\n");
+  // Rewrite the stored job to the real-world shape that was dropped live: a
+  // complete document plus a bounded (partial) spreadsheet normalization.
+  const jobPath = join(root, ".kdlc/jobs", `${job.id}.json`);
+  const stored = JSON.parse(await readFile(jobPath, "utf8"));
+  const base = stored.result.normalized[0];
+  stored.result.normalized = [
+    base,
+    { ...base, manifest: { ...base.manifest, source_id: "src_csv", status: "partial", coverage: { discovered: 268, emitted: 1381 } } },
+    { ...base, manifest: { ...base.manifest, source_id: "src_bad", status: "failed" } }
+  ];
+  stored.request.sources = ["big.md", "forecast.csv", "broken.bin"];
+  await writeFile(jobPath, JSON.stringify(stored));
+
+  const result = await engine.execute("proposal", { scaffold: { job_id: job.id, all_sources: true, access: "internal", license: "LicenseRef-Internal" } });
+  assert.equal(result.scaffolds.length, 2, "complete AND partial sources scaffold");
+  const partial = result.scaffolds.find(({ source }) => source === "forecast.csv");
+  assert.match(partial.coverage, /partial coverage: bounded intake/, "the kit result discloses bounded coverage");
+  assert.match(await readFile(join(root, ".kdlc/drafting", partial.workflow_id, "README.md"), "utf8"), /partial coverage/, "the kit README leads with the disclosure");
+  const { context } = JSON.parse(await readFile(join(root, ".kdlc/governed/review-contexts", `${partial.workflow_id}.json`), "utf8"));
+  assert.equal(context.evidence[0].extraction_quality, "medium");
+  assert.match(context.evidence[0].warnings[0], /partial coverage/, "the governed record carries the disclosure");
+  // Undraftable sources are reported, never silently vanished.
+  assert.deepEqual(result.undraftable_sources, [{ source: "broken.bin", status: "failed" }]);
+  // Selecting the partial source by its ORIGINAL index works; the failed one refuses.
+  await engine.execute("proposal", { scaffold: { job_id: job.id, source: "1", access: "internal", license: "LicenseRef-Internal", workflow_id: "wf_partialpick11111" } })
+    .then((picked) => assert.equal(picked.source, "forecast.csv"));
+  await assert.rejects(
+    engine.execute("proposal", { scaffold: { job_id: job.id, source: "2", access: "internal", license: "LicenseRef-Internal" } }),
+    /did not normalize to a draftable state/
+  );
+});
+
+test("FEAT-042: sparse CLI input surfaces its real input error, not KDLC_CANONICAL_INVALID (#144)", async () => {
+  // parseCli must not plant undefined keys, and correlation must survive them.
+  const parsed = parseCli(["proposal", "--scaffold", "job_0123456789abcdef", "--all-sources", "--output", "json"]);
+  assert.ok(!("access" in parsed.input.scaffold), "no undefined access key");
+  assert.ok(!("license" in parsed.input.scaffold), "no undefined license key");
+  const envelope = await new KdlcEngine().envelope(parsed.operation, { scaffold: { job_id: "job_0123456789abcdef", access: undefined, license: undefined } });
+  assert.equal(envelope.ok, false);
+  assert.notEqual(envelope.error.code, "KDLC_CANONICAL_INVALID", "correlation survives sparse input");
+});


### PR DESCRIPTION
Closes #144.

Reported live from Kiro IDE dogfooding: a three-source ingest (two .eml + one .csv) normalized everything, but the large CSV's bounded intake yielded `manifest.status: "partial"` and the scaffold's `status === "complete"` filter silently dropped it — even under `--all-sources`. The user's question was "it didn't process csv file"; it had, and then the evidence vanished at the drafting step.

Fixes, all regression-locked:
- Partial normalizations now scaffold. The disclosure rides everywhere a human or the governed record looks: the scaffold result (`coverage: "partial coverage: bounded intake emitted N units …; claims must not present this as a full read of the source"`), the kit README's first line, and the review-context evidence (`extraction_quality: "medium"` + warning).
- Statuses that genuinely cannot draft are reported as `undraftable_sources` — never omitted. `--source <n>` now uses original job indexes (so the menu, the job, and the flag agree) and refuses undraftable ones with the status named.
- The same command's missing-`--access` error had surfaced as `KDLC_CANONICAL_INVALID`: parseCli planted explicit `undefined` access/license keys and the correlation-id digest canonicalizes the raw input before any error handling could wrap it. parseCli no longer emits undefined keys, and correlation strips undefined defensively (well-formed inputs hash unchanged).

Verified live on the reporting project: the CSV scaffolded as its own workflow (1340 draftable units, disclosure present), the two .eml sources skip-existing correctly, and the sparse-input command now prints the real governance guidance.

## Traceability
- Requirement IDs: FEAT-042
- Specification section(s): sections 14 (normalization coverage honesty) and 25 (CLI envelope)

## Verification
Commands and results:
```text
npm test → tests 310, pass 310, fail 0 (new FEAT-042 tests: partial+complete+failed job shape —
  scaffolds, README/result/review-context disclosures, undraftable_sources, original-index --source,
  refusal message; sparse-input envelope keeps its real error code)
node scripts/verify-governance.mjs → Governance verified: 54 traceable requirements and 5 gates
Live: proposal --scaffold <job> --all-sources → CSV workflow s2 created with coverage note; bare
  re-run without flags → KDLC_INPUT_INVALID with the access/license guidance (was KDLC_CANONICAL_INVALID)
```
