### PR TITLE
fix: lock names survive deep paths, orphaned leases reclaim (#146) [FEAT-043]

### DIFF
--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -14,5 +14,5 @@
   "tools": ["project_init", "project_get", "project_list_mounts", "kb_search", "kb_fetch", "kb_trace", "kb_conflicts", "kb_gaps", "source_excerpt", "job_status", "ingest_start", "proposal_create", "review_submit", "publish_request", "job_cancel"],
   "transports": ["stdio", "streamable-http"],
   "pending_requirements": [],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:dbc0870da719a47790f6b675c7d25ebb1b26f1799d0dbf822331b825b91356d0"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:1f898463f9b4565a8e01a212d5285f0cb0741339fd877dbd40217d0fab4f4b57"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -1254,6 +1254,25 @@
           "tests/governance/drafting-scaffold.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-043",
+      "title": "Lock names survive deep target paths; orphaned leases reclaim with audit",
+      "issue": 146,
+      "specification_sections": [
+        "25",
+        "27"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "packages/lifecycle/src/locks.mjs",
+          "packages/lifecycle/src/store.mjs"
+        ],
+        "tests": [
+          "tests/governance/lock-resilience.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/packages/lifecycle/src/locks.mjs
+++ b/packages/lifecycle/src/locks.mjs
@@ -4,9 +4,16 @@ import { conflict, denied } from "./errors.mjs";
 
 export class LeaseLockManager {
   constructor({ store, clock, audit, ids, coordination = {} }) { Object.assign(this, { store, clock, audit, ids }); this.coordination = coordination; }
-  path(resource) { return `workflow/locks/${encodeURIComponent(resource)}`; }
+  // Deep target paths must never overflow a filesystem's 255-byte filename
+  // component: long encoded resources keep a readable prefix and bind the
+  // full identity through a content hash (#146).
+  fileName(resource) {
+    const encoded = encodeURIComponent(resource);
+    return encoded.length <= 150 ? encoded : `${encoded.slice(0, 96)}...${this.store.token(resource).slice(7, 39)}`;
+  }
+  path(resource) { return `workflow/locks/${this.fileName(resource)}`; }
   recordPath(resource) { return `${this.path(resource)}/lease.json`; }
-  adminPath(resource) { return `workflow/lock-admin/${encodeURIComponent(resource)}`; }
+  adminPath(resource) { return `workflow/lock-admin/${this.fileName(resource)}`; }
   owner(operation, resource) { return `${operation}:${resource}:${this.ids?.next?.("coord") ?? `${process.pid}-${Date.now()}`}`; }
   coordinated(resource, operation, action) {
     return this.store.withMutex(this.adminPath(resource), { owner: this.owner(operation, resource), clock: this.clock, ...this.coordination }, action);
@@ -14,11 +21,27 @@ export class LeaseLockManager {
   async acquire(resource, { owner, process, leaseMs, recovery = {} }) {
     return this.coordinated(resource, "acquire", async () => {
       const lockPath = this.path(resource);
-      try { await this.store.createDirectoryExclusive(lockPath); }
+      const tryCreate = async () => { await this.store.createDirectoryExclusive(lockPath); };
+      try { await tryCreate(); }
       catch (error) {
         if (error.code !== "EEXIST") throw error;
         const held = await this.store.exists(this.recordPath(resource)) ? await this.store.readJson(this.recordPath(resource)) : null;
-        throw conflict("Resource is locked", { resource, owner: held?.owner, expires_at: held?.expires_at, empty: !held });
+        // A lease whose owner process is provably dead and whose lease has
+        // expired is an orphan (e.g. a holder that crashed before writing a
+        // journal): break it with an audit record instead of wedging every
+        // future publish on this target (#146). Live or unverifiable owners
+        // still conflict fail-closed.
+        const orphaned = held
+          ? Date.parse(held.expires_at) <= this.clock.millis() && this.store.processIsAlive(held.process_id) === false
+          : (this.clock.millis() - (await stat(await this.store.safePath(lockPath))).mtimeMs) >= (this.coordination.emptyGraceMs ?? 30_000);
+        if (!orphaned) throw conflict("Resource is locked", { resource, owner: held?.owner, expires_at: held?.expires_at, empty: !held });
+        if (this.audit && held?.recovery?.workflow_id) await this.audit.append(held.recovery.workflow_id, {
+          actor: owner, action: "lock.broken", subject: resource, result: "stale", reason: "expired lease with dead owner process",
+          prior_owner: held.owner, idempotency_key: `lock-orphan:${this.store.token(JSON.stringify([resource, held.owner, held.lease_id]))}`
+        });
+        if (held) await this.store.remove(this.recordPath(resource)).catch(() => {});
+        await this.store.removeDirectory(lockPath);
+        await tryCreate();
       }
       const processId = Number(process);
       if (!Number.isSafeInteger(processId) || processId <= 0) throw conflict("Lock requires a valid local process ID", { resource });

--- a/packages/lifecycle/src/store.mjs
+++ b/packages/lifecycle/src/store.mjs
@@ -266,7 +266,9 @@ export class NodeFileStore {
         }
         if (stale) {
           const claimPath = `${relativePath}.reclaim`;
-          const recovery = `${relativePath}.recovery-${encodeURIComponent(owner)}`;
+          // Hash the owner: it embeds the resource name, and appending it
+          // verbatim can overflow the filename component limit (#146).
+          const recovery = `${relativePath}.recovery-${this.token(owner).slice(7, 39)}`;
           let ownsClaim = false;
           try {
             const claim = await this.safePath(claimPath);

--- a/tests/governance/lock-resilience.test.mjs
+++ b/tests/governance/lock-resilience.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { LeaseLockManager } from "../../packages/lifecycle/src/locks.mjs";
+import { NodeFileStore } from "../../packages/lifecycle/src/index.mjs";
+
+const clock = { now: () => new Date().toISOString(), millis: () => Date.now() };
+
+test("FEAT-043: deep target paths never overflow the lock filename limit (#146)", async () => {
+  const root = await mkdtemp(join(tmpdir(), "kdlc-locknames-"));
+  const store = new NodeFileStore(root);
+  const locks = new LeaseLockManager({ store, clock });
+  // The live failure: a nested concept path whose encoded resource, doubled
+  // into the recovery marker, exceeded 255 bytes and ENAMETOOLONG'd publish.
+  const resource = "transaction-target:knowledge/primary/concepts/supplier/triumph-insulation-systems/and-some/considerably/deeper/nesting/lead-time-forecast-with-a-long-name.md";
+  const lease = await locks.acquire(resource, { owner: "txn_test", process: process.pid, leaseMs: 60_000 });
+  assert.ok(lease.lease_id);
+  for (const directory of ["workflow/locks", "workflow/lock-admin"]) {
+    for (const name of await readdir(join(root, directory))) {
+      assert.ok(Buffer.byteLength(name) <= 200, `${directory}/${name} stays clear of the 255-byte filename limit`);
+    }
+  }
+  // Distinct long resources must not collide after truncation-with-hash.
+  const sibling = resource.replace("lead-time-forecast", "different-forecast");
+  const other = await locks.acquire(sibling, { owner: "txn_other", process: process.pid, leaseMs: 60_000 });
+  assert.notEqual(locks.path(resource), locks.path(sibling));
+  await locks.release(resource, "txn_test", lease.lease_id);
+  await locks.release(sibling, "txn_other", other.lease_id);
+});
+
+test("FEAT-043: an orphaned lease (expired, dead owner, no journal) is reclaimed instead of wedging the target (#146)", async () => {
+  const root = await mkdtemp(join(tmpdir(), "kdlc-orphan-"));
+  const store = new NodeFileStore(root);
+  const events = [];
+  const audit = { append: async (workflowId, event) => { events.push({ workflowId, ...event }); } };
+  const past = { now: () => new Date(Date.now() - 3_600_000).toISOString(), millis: () => Date.now() - 3_600_000 };
+  const resource = "transaction-target:knowledge/primary/concepts/x.md";
+  // A holder that crashed an hour ago: expired lease, provably dead pid.
+  const stale = new LeaseLockManager({ store, clock: past, audit });
+  await stale.acquire(resource, { owner: "txn_dead", process: 999999, leaseMs: 1_000, recovery: { workflow_id: "wf_dead", transaction_id: "txn_dead" } });
+
+  const live = new LeaseLockManager({ store, clock, audit });
+  const lease = await live.acquire(resource, { owner: "txn_live", process: process.pid, leaseMs: 60_000 });
+  assert.equal(lease.owner, "txn_live", "the orphan is broken and the new holder proceeds");
+  const broken = events.find(({ action }) => action === "lock.broken");
+  assert.ok(broken, "breaking an orphan is audited");
+  assert.equal(broken.prior_owner, "txn_dead");
+
+  // A LIVE holder still conflicts fail-closed.
+  await assert.rejects(
+    live.acquire(resource, { owner: "txn_second", process: process.pid, leaseMs: 60_000 }),
+    (error) => /locked/i.test(error.message)
+  );
+  // An expired lease whose owner process is STILL ALIVE also conflicts —
+  // liveness is the fail-closed side of the orphan test.
+  await live.release(resource, "txn_live", lease.lease_id);
+  const expiredAlive = new LeaseLockManager({ store, clock: past, audit });
+  await expiredAlive.acquire(resource, { owner: "txn_expired_alive", process: process.pid, leaseMs: 1_000 });
+  await assert.rejects(
+    live.acquire(resource, { owner: "txn_third", process: process.pid, leaseMs: 60_000 }),
+    (error) => /locked/i.test(error.message)
+  );
+});


### PR DESCRIPTION
Closes #146.

Reported live from Kiro IDE dogfooding: publishing `supplier/triumph-insulation-systems/lead-time-forecast.md` failed as `KDLC_INTERNAL`. Two engine defects underneath:

1. **ENAMETOOLONG on deep paths.** Lock filenames URL-encode the full target resource, and the mutex stale-recovery marker appends the owner — which embeds the resource *again* — so a nested concept path overflowed the 255-byte filename component. Fix: lock/lock-admin filenames over 150 chars keep a readable 96-char prefix and bind full identity via content hash (distinct long resources cannot collide); recovery markers hash the owner instead of embedding it.
2. **Orphaned leases wedged the target.** The crash above died mid-acquisition — target leases held, no journal written, and the cleanup release failed on the same long filename. `acquire` treated any existing lock as a hard conflict, so the target was permanently unpublishable. Fix: a lease that is expired AND whose owner process is provably dead is reclaimed with an audited `lock.broken` record; live or unverifiable owners (including expired-but-alive) still conflict fail-closed. Empty lock dirs reclaim after the existing 30s grace.

Verified live on the reporting project: the wedged publish now completes — concept materialized, catalog updated, revision-pinned citations available.

## Traceability
- Requirement IDs: FEAT-043
- Specification section(s): sections 25 (envelope honesty) and 27 (lifecycle transactions and lock administration)

## Verification
Commands and results:
```text
npm test → tests 312, pass 312, fail 0 — including the PINNED lifecycle-concurrency corpus untouched
  and new tests/governance/lock-resilience.test.mjs (deep-path filenames ≤200 bytes, no collision between
  distinct long resources, orphan reclaim audited, live/expired-but-alive holders still conflict)
node scripts/verify-governance.mjs → Governance verified: 55 traceable requirements and 5 gates
Live: kdlc publish pr_csvleadtimeforecast --receipt rr_228d60234454 → materialized:true (was KDLC_INTERNAL)
```
