### PR TITLE
docs: README OKF link points at SPEC.md (#152) [FEAT-046]

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ already has — wikis, PDFs, Word docs, emails, spreadsheets, decks, diagrams,
 web pages, and pages living in **Confluence, SharePoint, OneDrive, or Google
 Drive** — into durable, provenance-bearing knowledge that AI agents can
 actually trust: curated, linked Markdown concepts in the
-[Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)
+[Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 (schemas vendored at [core/schemas/okf-0.2/](core/schemas/okf-0.2/)), produced through a
 governed lifecycle with explicit human approval gates. Think of it as a
 governed knowledge base builder for the agent era: every answer cites the

--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -14,5 +14,5 @@
   "tools": ["project_init", "project_get", "project_list_mounts", "kb_search", "kb_fetch", "kb_trace", "kb_conflicts", "kb_gaps", "source_excerpt", "job_status", "ingest_start", "proposal_create", "review_submit", "publish_request", "job_cancel"],
   "transports": ["stdio", "streamable-http"],
   "pending_requirements": [],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:be9a906b9ce6ea6c78dbe19aed650ad26b9abb4fa1dabc3215d999d38cb4484f"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:fd823dda8a52efb5bc35598e088b297037db1ed6a62b071199ff4c68127683d7"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -1311,6 +1311,21 @@
           "tests/governance/drafting-scaffold.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-046",
+      "title": "README OKF reference links directly to the OKF specification document",
+      "issue": 152,
+      "specification_sections": [
+        "2"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "README.md"
+        ],
+        "tests": []
+      }
     }
   ]
 }


### PR DESCRIPTION
Closes #152.

The README's OKF reference now links directly to the specification document (blob/main/okf/SPEC.md) instead of the okf/ directory listing. The normative pinned-commit reference in the K-DLC specification (§2, commit-pinned with sha256) is deliberately unchanged — the README link is the friendly front door, the spec table remains the reproducible one.

## Traceability
- Requirement IDs: FEAT-046
- Specification section(s): section 2 (normative references; the README mirrors its subject)

## Verification
Commands and results:
```text
npm test → tests 314, pass 314, fail 0
node scripts/verify-governance.mjs → Governance verified: 58 traceable requirements and 5 gates
git diff: one link changed in README.md; traceability entry + conformance sha rebind only
```
