### PR TITLE
feat: stable editorial metadata gate, ranked tags (#156) [FEAT-048]

### DIFF
--- a/distribution/release/conformance-statement.json
+++ b/distribution/release/conformance-statement.json
@@ -14,5 +14,5 @@
   "tools": ["project_init", "project_get", "project_list_mounts", "kb_search", "kb_fetch", "kb_trace", "kb_conflicts", "kb_gaps", "source_excerpt", "job_status", "ingest_start", "proposal_create", "review_submit", "publish_request", "job_cancel"],
   "transports": ["stdio", "streamable-http"],
   "pending_requirements": [],
-  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:fd6026d521b5d5e38555562cdcece9f606cedad3751696016fa6b4ca29befca8"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
+  "evidence": [{"path":"distribution/release/evaluation-report.json","sha256":"sha256:91ac77187c3d09fdf0a8d17ddda589d2afd276fe387ed7555a675073b6ee56da"},{"path":"docs/traceability.json","sha256":"sha256:f2f3d2b883dbbd23144905321c9f1c9eac8c613e244513a0dffae7a46886b189"},{"path":"docs/release-readiness.md","sha256":"sha256:759a9a58ca4032d9fedb21732cfd1fd4962f1a768b537b4a87c03f2e24306f63"}]
 }

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -1347,6 +1347,26 @@
           "tests/governance/drafting-scaffold.test.mjs"
         ]
       }
+    },
+    {
+      "id": "FEAT-048",
+      "title": "Stable-tier editorial metadata enforced; tags ranked and rendered",
+      "issue": 156,
+      "specification_sections": [
+        "2",
+        "14.2",
+        "25"
+      ],
+      "status": "implemented",
+      "evidence": {
+        "implementation": [
+          "packages/cli/index.mjs",
+          "packages/retrieval/src/retriever.mjs"
+        ],
+        "tests": [
+          "tests/governance/drafting-scaffold.test.mjs"
+        ]
+      }
     }
   ]
 }

--- a/packages/cli/index.mjs
+++ b/packages/cli/index.mjs
@@ -1341,10 +1341,24 @@ export function createLocalProjectEngine(options = {}) {
         // Concepts reviewed without them keep the pre-FEAT-033 contract —
         // authorization recorded, nothing materialized — with the reason
         // stated so the drafter can fix and re-review.
+        // FEAT-048 (#156): §14.2 stable-publication requirements. Draft-tier
+        // concepts stay lenient (that is their point); anything else must
+        // carry the editorial metadata the spec requires before it lands.
+        const stableTier = frontmatter.status !== "draft";
+        const today = new Date().toISOString().slice(0, 10);
+        const editorialGaps = !stableTier ? [] : [
+          ...(typeof frontmatter.type === "string" && frontmatter.type.trim() ? [] : ["type"]),
+          ...(typeof frontmatter.title === "string" && frontmatter.title.trim() ? [] : ["title"]),
+          ...(typeof frontmatter.description === "string" && frontmatter.description.trim() ? [] : ["description"]),
+          ...(frontmatter.freshness === "timeless" || (typeof frontmatter.stale_after === "string" && frontmatter.stale_after > today)
+            ? [] : ["stale_after (a future YYYY-MM-DD, or freshness: timeless)"]),
+        ];
         const missingMetadata = !frontmatter.access || typeof frontmatter.access.classification !== "string"
           ? `the concept frontmatter lacks access.classification (e.g. "${kbAccess}")`
           : (frontmatter.sources ?? []).filter((source) => typeof source.resource !== "string" || !source.access?.classification || !source.rights?.license)
-              .map((source) => `source "${source.id}" lacks resource/access/rights`).join("; ") || null;
+              .map((source) => `source "${source.id}" lacks resource/access/rights`).join("; ") || (editorialGaps.length
+            ? `a stable concept requires ${editorialGaps.join(", ")} (§14.2) — declare status: "draft" if it is not ready for the stable tier`
+            : null);
         if (missingMetadata) {
           return { materialized: false, reason: `${missingMetadata} — retrieval binds to these reviewed fields, so the intent is recorded but the concept was not published to the knowledge base; add them in the drafting template and re-review` };
         }
@@ -1798,7 +1812,11 @@ export function createLocalProjectEngine(options = {}) {
       "2. Add proposals: `kdlc.dev/concept-proposal/v1alpha1` entries with `id` matching pr_<lowercase+digits>,",
       "   `workflow_id: \"" + workflowId + "\"`, `task: \"ingest\"`, `state: \"review_pending\"`, a `target`",
       "   (knowledge_base_id/revision/subject), the OKF `concept` ({before: null, after: {frontmatter, body}}) —",
-      "   frontmatter MUST include `access: {classification: \"" + access + "\"}` (retrieval binds to it) and",
+      "   frontmatter MUST include `access: {classification: \"" + access + "\"}` (retrieval binds to it);",
+      "   a STABLE concept additionally requires `type`, `title`, `description`, and a future `stale_after`",
+      "   (or `freshness: \"timeless\"`) — publication refuses stable concepts without them (§14.2); declare",
+      "   `status: \"draft\"` while content is not ready for that bar. `tags: [..]` are recommended —",
+      "   retrieval ranks tag matches and the knowledge map shows them — and",
       "   each `sources` entry MUST carry `id`, `resource` (e.g. \"file:sources/<name>\"), `source_hash`,",
       "   `access` and `rights` matching this kit's declarations (answers are withheld unless the requester",
       "   may see the concept AND every disclosed source),",
@@ -1918,7 +1936,7 @@ export function createLocalProjectEngine(options = {}) {
           for (const entry of catalog.concepts) {
             let fm = {};
             try { fm = parseYaml((await catalogStore.readText(`${base}/${entry.path}`)).split(/^---$/m)[1] ?? "") ?? {}; } catch { /* node still renders */ }
-            nodes.push({ id: entry.id, title: String(fm.title ?? entry.id), description: String(fm.description ?? ""), type: String(fm.type ?? "Concept"), status: String(fm.status ?? "stable"), access: entry.access?.classification ?? "internal" });
+            nodes.push({ id: entry.id, title: String(fm.title ?? entry.id), description: String(fm.description ?? ""), type: String(fm.type ?? "Concept"), status: String(fm.status ?? "stable"), access: entry.access?.classification ?? "internal", tags: Array.isArray(fm.tags) ? fm.tags.map(String) : [] });
             for (const relationship of fm.relationships ?? []) {
               const target = String(relationship?.target ?? "").replace(/^kb:\/\/[^/]+\//, "");
               if (target) edges.push({ from: entry.id, to: `concepts/${target}`.replace(/^concepts\/concepts\//, "concepts/"), kind: String(relationship?.type ?? "related") });
@@ -1938,7 +1956,7 @@ for(let t=0;t<300;t++){for(let i=0;i<pos.length;i++)for(let j=i+1;j<pos.length;j
 for(const e of DATA.edges){const a=pos[idx.get(e.from)],b=pos[idx.get(e.to)];if(!a||!b)continue;const dx=b.x-a.x,dy=b.y-a.y,d=Math.sqrt(dx*dx+dy*dy)+0.01,f=(d-120)*0.01;a.vx+=dx/d*f;a.vy+=dy/d*f;b.vx-=dx/d*f;b.vy-=dy/d*f;}
 for(const q of pos){q.vx+=(W()/2-q.x)*0.002;q.vy+=(H()/2-q.y)*0.002;q.x+=q.vx*=0.85;q.y+=q.vy*=0.85;}}
 for(const e of DATA.edges){const a=pos[idx.get(e.from)],b=pos[idx.get(e.to)];if(!a||!b)continue;const l=document.createElementNS(ns,"line");l.setAttribute("x1",a.x);l.setAttribute("y1",a.y);l.setAttribute("x2",b.x);l.setAttribute("y2",b.y);svg.appendChild(l);}
-DATA.nodes.forEach((n,i)=>{const g=document.createElementNS(ns,"g");const c=document.createElementNS(ns,"circle");c.setAttribute("cx",pos[i].x);c.setAttribute("cy",pos[i].y);c.setAttribute("r",9);c.setAttribute("class",n.status);c.addEventListener("click",()=>{detail.innerHTML="";const h=document.createElement("h3");h.textContent=n.title;const meta=document.createElement("p");meta.textContent=n.type+" · "+n.status+" · "+n.access;const p=document.createElement("p");p.textContent=n.description;const code=document.createElement("code");code.textContent="kb://"+n.id;detail.append(h,meta,p,code);});
+DATA.nodes.forEach((n,i)=>{const g=document.createElementNS(ns,"g");const c=document.createElementNS(ns,"circle");c.setAttribute("cx",pos[i].x);c.setAttribute("cy",pos[i].y);c.setAttribute("r",9);c.setAttribute("class",n.status);c.addEventListener("click",()=>{detail.innerHTML="";const h=document.createElement("h3");h.textContent=n.title;const meta=document.createElement("p");meta.textContent=n.type+" · "+n.status+" · "+n.access+(n.tags.length?" · #"+n.tags.join(" #"):"");const p=document.createElement("p");p.textContent=n.description;const code=document.createElement("code");code.textContent="kb://"+n.id;detail.append(h,meta,p,code);});
 const t=document.createElementNS(ns,"text");t.setAttribute("x",pos[i].x+11);t.setAttribute("y",pos[i].y+4);t.textContent=n.title.slice(0,28);g.append(c,t);svg.appendChild(g);});
 </script>`;
           await writeFile(resolve(root, base, "viz.html"), html);

--- a/packages/cli/index.mjs
+++ b/packages/cli/index.mjs
@@ -1357,7 +1357,7 @@ export function createLocalProjectEngine(options = {}) {
           ? `the concept frontmatter lacks access.classification (e.g. "${kbAccess}")`
           : (frontmatter.sources ?? []).filter((source) => typeof source.resource !== "string" || !source.access?.classification || !source.rights?.license)
               .map((source) => `source "${source.id}" lacks resource/access/rights`).join("; ") || (editorialGaps.length
-            ? `a stable concept requires ${editorialGaps.join(", ")} (§14.2) — declare status: "draft" if it is not ready for the stable tier`
+            ? `a stable concept requires ${editorialGaps.join(", ")} (§14.2) — declare status: "draft" (lowercase; any other spelling counts as stable) if it is not ready for the stable tier`
             : null);
         if (missingMetadata) {
           return { materialized: false, reason: `${missingMetadata} — retrieval binds to these reviewed fields, so the intent is recorded but the concept was not published to the knowledge base; add them in the drafting template and re-review` };
@@ -1529,6 +1529,22 @@ export function createLocalProjectEngine(options = {}) {
         if (rationale.ratified) throw new EngineError("KDLC_STATE_CONFLICT", `${proposalId} is already ratified`, EXIT.conflict);
         const original = await store.get(`workflow/runs/${workflowId}/proposals/${proposalId}.json`);
         if (original.concept.after.frontmatter.status !== "draft") throw inputError(`${proposalId} is not a draft-tier concept`);
+        // FEAT-048 (#156): ratification promotes to stable, so the §14.2
+        // editorial bar applies — check BEFORE minting the promotion
+        // workflow, or a refused promotion wedges the deterministic proposal
+        // id against an orphaned run (review MEDIUM).
+        const draftFrontmatter = original.concept.after.frontmatter;
+        const ratifyToday = new Date().toISOString().slice(0, 10);
+        const ratifyGaps = [
+          ...(typeof draftFrontmatter.type === "string" && draftFrontmatter.type.trim() ? [] : ["type"]),
+          ...(typeof draftFrontmatter.title === "string" && draftFrontmatter.title.trim() ? [] : ["title"]),
+          ...(typeof draftFrontmatter.description === "string" && draftFrontmatter.description.trim() ? [] : ["description"]),
+          ...(draftFrontmatter.freshness === "timeless" || (typeof draftFrontmatter.stale_after === "string" && draftFrontmatter.stale_after > ratifyToday)
+            ? [] : ["stale_after (a future YYYY-MM-DD, or freshness: timeless)"]),
+        ];
+        if (ratifyGaps.length > 0) {
+          throw inputError(`ratifying ${proposalId} would promote it to stable, but the draft lacks ${ratifyGaps.join(", ")} (§14.2) — re-draft the concept with the missing metadata (kdlc proposal --scaffold from its evidence) and publish the update, then ratify`);
+        }
         const evidence = await store.get(`workflow/runs/${workflowId}/state/normalized-evidence.json`);
         const claims = [];
         for (const claimId of original.claim_ids) claims.push(await store.get(`workflow/runs/${workflowId}/claims/${claimId}.json`));

--- a/packages/retrieval/src/retriever.mjs
+++ b/packages/retrieval/src/retriever.mjs
@@ -25,7 +25,10 @@ function stale(frontmatter, today) { return frontmatter.stale_after !== undefine
 function list(value) { return Array.isArray(value) ? value : []; }
 function rawScore(query, concept) {
   const title = terms(concept.frontmatter.title ?? concept.id); const description = terms(concept.frontmatter.description ?? ""); const body = terms(concept.body);
-  return query.reduce((score, term) => score + (title.includes(term) ? 5 : 0) + (description.includes(term) ? 3 : 0) + (body.includes(term) ? 1 : 0), 0);
+  // Tags are curated signals: a tag match outranks prose mentions but not
+  // the title itself (FEAT-048).
+  const tags = terms((Array.isArray(concept.frontmatter.tags) ? concept.frontmatter.tags : []).join(" "));
+  return query.reduce((score, term) => score + (title.includes(term) ? 5 : 0) + (tags.includes(term) ? 4 : 0) + (description.includes(term) ? 3 : 0) + (body.includes(term) ? 1 : 0), 0);
 }
 function noDisclosure() {
   return { status: "not_found", results: [], citations: [], conflicts: [], warnings: [], timing_class: "bounded-floor" };

--- a/tests/governance/drafting-scaffold.test.mjs
+++ b/tests/governance/drafting-scaffold.test.mjs
@@ -578,7 +578,7 @@ test("FEAT-048: stable publication enforces the §14.2 editorial metadata; draft
   await new KdlcEngine({ root }).execute("init", { project_id: "editorial.fixture" });
   const engine = createLocalProjectEngine({ root });
   const rights = { license: "LicenseRef-Internal", redistribution: "prohibited", derivative_use: "allowed", commercial_use: "prohibited" };
-  const submitOne = async (filename, marker, proposalId, frontmatterExtra) => {
+  const submitOne = async (filename, marker, proposalId, frontmatterExtra, { auto = false } = {}) => {
     const job = await completedIngest(engine, root, filename, `# S\n\n## Fact\n\n${marker} is recorded here.\n`);
     const scaffold = await engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "LicenseRef-Internal" } });
     const kit = join(root, ".kdlc/drafting", scaffold.workflow_id);
@@ -590,7 +590,11 @@ test("FEAT-048: stable publication enforces the §14.2 editorial metadata; draft
     template.claims = [{ id: claimId, text: unit.text, source_id: evidence.source_id, source_hash: evidence.source_hash, locator: unit.locator, extraction: "explicit", status: "accepted", access: { classification: "internal" }, rights }];
     template.proposals = [{ api_version: "kdlc.dev/concept-proposal/v1alpha1", id: proposalId, workflow_id: scaffold.workflow_id, task: "ingest", state: "review_pending", target: { knowledge_base_id: "local.editorial", revision: "rev-1", subject: `kb://local.editorial/notes/${proposalId.slice(3)}` }, concept: { before: null, after: { frontmatter: { title: marker, access: { classification: "internal" }, generated: { by: "kdlc-integrator/0.2.0", at: "2026-08-16T20:30:00Z" }, sources: [{ id: "s", resource: `file:${filename}`, source_hash: evidence.source_hash, access: { classification: "internal" }, rights }], ...frontmatterExtra }, body: `# ${marker}\n\nBody.\n` } }, claim_ids: [claimId], claim_decisions: [{ claim_id: claimId, disposition: "accepted", rationale: "explicit" }], created_by: "kdlc-integrator/0.2.0" }];
     await writeFile(join(kit, "recording-template.json"), JSON.stringify(template));
-    const submitted = await engine.execute("proposal", { submit: { workflow_id: scaffold.workflow_id } });
+    if (auto) {
+      const submitted = await engine.execute("proposal", { submit: { workflow_id: scaffold.workflow_id, auto: true } });
+      return { published: submitted.published ?? submitted.publications?.[0]?.published ?? submitted };
+    }
+    await engine.execute("proposal", { submit: { workflow_id: scaffold.workflow_id } });
     return engine.execute("publish", { proposal_id: proposalId, decide: "approved", reason: "test" });
   };
   // Stable (default status) without type/description/stale_after: approval
@@ -600,8 +604,19 @@ test("FEAT-048: stable publication enforces the §14.2 editorial metadata; draft
   assert.match(refused.published.reason, /§14\.2/);
   assert.match(refused.published.reason, /type, description, stale_after/);
   // Draft tier stays lenient: same gaps, but declared draft — it lands.
-  const draft = await submitOne("b.md", "BetaFact", "pr_betafact", { status: "draft" });
-  assert.equal(draft.published.materialized, true);
+  const draft = await submitOne("b.md", "BetaFact", "pr_betafact", { status: "draft" }, { auto: true });
+  assert.ok(draft.published, "auto submit publishes the draft");
+  // Ratifying a metadata-poor draft refuses BEFORE minting the promotion
+  // workflow — with re-draft guidance, and retryable (review MEDIUM).
+  await assert.rejects(
+    engine.execute("revisit", { proposal_id: "pr_betafact", reason: "ratify it" }),
+    /would promote it to stable, but the draft lacks type, description, stale_after/
+  );
+  await assert.rejects(
+    engine.execute("revisit", { proposal_id: "pr_betafact", reason: "ratify again" }),
+    /would promote it to stable/,
+    "the refusal is retryable — no orphaned promotion workflow wedges the id"
+  );
   // Full editorial metadata (with timeless freshness) lands at stable.
   const full = await submitOne("c.md", "GammaFact", "pr_gammafact", { type: "Note", description: "A complete note.", freshness: "timeless", tags: ["gamma", "editorial"] });
   assert.equal(full.published.materialized, true);

--- a/tests/governance/drafting-scaffold.test.mjs
+++ b/tests/governance/drafting-scaffold.test.mjs
@@ -572,3 +572,41 @@ test("FEAT-047: visualize renders a self-contained knowledge map from the catalo
   assert.match(html, /A mapped policy\./);
   assert.ok(!/https?:\/\//.test(html.replace(/http:\/\/www\.w3\.org\/2000\/svg/g, "")), "no external dependencies");
 });
+
+test("FEAT-048: stable publication enforces the §14.2 editorial metadata; drafts stay lenient (#156)", async () => {
+  const root = await mkdtemp(join(tmpdir(), "kdlc-editorial-"));
+  await new KdlcEngine({ root }).execute("init", { project_id: "editorial.fixture" });
+  const engine = createLocalProjectEngine({ root });
+  const rights = { license: "LicenseRef-Internal", redistribution: "prohibited", derivative_use: "allowed", commercial_use: "prohibited" };
+  const submitOne = async (filename, marker, proposalId, frontmatterExtra) => {
+    const job = await completedIngest(engine, root, filename, `# S\n\n## Fact\n\n${marker} is recorded here.\n`);
+    const scaffold = await engine.execute("proposal", { scaffold: { job_id: job.id, access: "internal", license: "LicenseRef-Internal" } });
+    const kit = join(root, ".kdlc/drafting", scaffold.workflow_id);
+    const evidence = JSON.parse(await readFile(join(kit, "normalized-evidence.json"), "utf8"));
+    const template = JSON.parse(await readFile(join(kit, "recording-template.json"), "utf8"));
+    const unit = evidence.units.find(({ text }) => text.includes(marker));
+    const claimId = `clm_${proposalId.slice(3)}`;
+    template.model = { provider: "recorded", model: "t", prompt: "p", recorded_at: template.model.recorded_at };
+    template.claims = [{ id: claimId, text: unit.text, source_id: evidence.source_id, source_hash: evidence.source_hash, locator: unit.locator, extraction: "explicit", status: "accepted", access: { classification: "internal" }, rights }];
+    template.proposals = [{ api_version: "kdlc.dev/concept-proposal/v1alpha1", id: proposalId, workflow_id: scaffold.workflow_id, task: "ingest", state: "review_pending", target: { knowledge_base_id: "local.editorial", revision: "rev-1", subject: `kb://local.editorial/notes/${proposalId.slice(3)}` }, concept: { before: null, after: { frontmatter: { title: marker, access: { classification: "internal" }, generated: { by: "kdlc-integrator/0.2.0", at: "2026-08-16T20:30:00Z" }, sources: [{ id: "s", resource: `file:${filename}`, source_hash: evidence.source_hash, access: { classification: "internal" }, rights }], ...frontmatterExtra }, body: `# ${marker}\n\nBody.\n` } }, claim_ids: [claimId], claim_decisions: [{ claim_id: claimId, disposition: "accepted", rationale: "explicit" }], created_by: "kdlc-integrator/0.2.0" }];
+    await writeFile(join(kit, "recording-template.json"), JSON.stringify(template));
+    const submitted = await engine.execute("proposal", { submit: { workflow_id: scaffold.workflow_id } });
+    return engine.execute("publish", { proposal_id: proposalId, decide: "approved", reason: "test" });
+  };
+  // Stable (default status) without type/description/stale_after: approval
+  // recorded, nothing materialized, reason names §14.2 and the gaps.
+  const refused = await submitOne("a.md", "AlphaFact", "pr_alphafact", {});
+  assert.equal(refused.published.materialized, false);
+  assert.match(refused.published.reason, /§14\.2/);
+  assert.match(refused.published.reason, /type, description, stale_after/);
+  // Draft tier stays lenient: same gaps, but declared draft — it lands.
+  const draft = await submitOne("b.md", "BetaFact", "pr_betafact", { status: "draft" });
+  assert.equal(draft.published.materialized, true);
+  // Full editorial metadata (with timeless freshness) lands at stable.
+  const full = await submitOne("c.md", "GammaFact", "pr_gammafact", { type: "Note", description: "A complete note.", freshness: "timeless", tags: ["gamma", "editorial"] });
+  assert.equal(full.published.materialized, true);
+  // Tags rank: a query matching only the tag finds the concept ahead of
+  // body-only matches elsewhere.
+  const answer = await engine.execute("query", { question: "editorial" });
+  assert.match(answer.results[0]?.id ?? "", /concepts\/notes\/gammafact$/);
+});


### PR DESCRIPTION
Closes #156.

Metadata completeness, closing the gap the dogfooding surfaced (concepts landing at the stable tier with no `type`/`status`; `tags` legal but inert):

1. **§14.2 enforced at publish for the stable tier** — same skip-not-refuse pattern as the access gate: a non-draft concept missing `type`, `title`, `description`, or a future `stale_after` (`freshness: "timeless"` accepted) gets its approval recorded but is not materialized, with the reason listing exactly the gaps and pointing at `status: "draft"` as the honest alternative. Draft tier stays lenient by design, so `--auto` batches are unaffected until ratification.
2. **The drafting kit teaches the bar** — the README now states the stable requirements and recommends `tags`, so conductors produce complete metadata by default.
3. **Tags earn their keep** — retrieval scores tag matches at weight 4 (between title 5 and description 3); the knowledge map's detail pane shows them.

## Traceability
- Requirement IDs: FEAT-048
- Specification section(s): sections 2 (OKF-native fields), 14.2 (stable publication requirements), and 25 (CLI surface)

## Verification
Commands and results:
```text
npm test → tests 316, pass 316, fail 0 — including the PINNED federation-retrieval corpus untouched
  (tag weighting adds score only on tag matches; fixtures unaffected). New FEAT-048 e2e through the real
  pipeline: stable-with-gaps refused naming §14.2 and the gaps; declared draft lands; full metadata with
  freshness: timeless lands; a tag-only query ranks the tagged concept first.
node scripts/verify-governance.mjs → Governance verified: 60 traceable requirements and 5 gates
```
